### PR TITLE
Switched to 100% CocoaPods-based project.

### DIFF
--- a/AudioKitSynthOne.xcodeproj/project.pbxproj
+++ b/AudioKitSynthOne.xcodeproj/project.pbxproj
@@ -1433,7 +1433,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../AudioKit/Frameworks/AudioKit-iOS/\"";
+				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1451,16 +1451,11 @@
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)",
 					"$(SRCROOT)",
-					"\"$(SRCROOT)/../AudioKit/Frameworks/AudioKit-iOS/AudioKit.framework/Headers/\"",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = (
-					"-lstdc++",
-					"-force_load",
-					"'$(SRCROOT)/../AudioKit/Frameworks/AudioKit-iOS/AudioKit.framework/AudioKit'",
-				);
+				OTHER_LDFLAGS = "-lstdc++";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/AudioKitSynthOne/DSP/AudioKitSynthOne-Bridging-Header.h";
@@ -1505,7 +1500,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../AudioKit/Frameworks/AudioKit-iOS/\"";
+				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1517,15 +1512,10 @@
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)",
 					"$(SRCROOT)",
-					"\"$(SRCROOT)/../AudioKit/Frameworks/AudioKit-iOS/AudioKit.framework/Headers/\"",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = (
-					"-lstdc++",
-					"-force_load",
-					"'$(SRCROOT)/../AudioKit/Frameworks/AudioKit-iOS/AudioKit.framework/AudioKit'",
-				);
+				OTHER_LDFLAGS = "-lstdc++";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/AudioKitSynthOne/DSP/AudioKitSynthOne-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -1547,23 +1537,10 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 9W69ZP8S5F;
-				HEADER_SEARCH_PATHS = (
-					"$(PROJECT_DIR)",
-					"$(SRCROOT)",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = AudioKitSynthOne/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"${PODS_ROOT}/Audiobus\"",
-				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-framework",
-					"\"Disk\"",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.audiokitpro.AudioKitSynthOne;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -1587,23 +1564,10 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 9W69ZP8S5F;
-				HEADER_SEARCH_PATHS = (
-					"$(PROJECT_DIR)",
-					"$(SRCROOT)",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = AudioKitSynthOne/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"${PODS_ROOT}/Audiobus\"",
-				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-framework",
-					"\"Disk\"",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.audiokitpro.AudioKitSynthOne;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";

--- a/AudioKitSynthOne/DSP/Audio Unit/S1AudioUnit.mm
+++ b/AudioKitSynthOne/DSP/Audio Unit/S1AudioUnit.mm
@@ -8,8 +8,8 @@
 
 #import "S1AudioUnit.h"
 #import "S1DSPKernel.hpp"
-#import "BufferedAudioBus.hpp"
 #import "AEMessageQueue.h"
+#import "AudioKit/BufferedAudioBus.hpp"
 #import <AudioKit/AudioKit-swift.h>
 
 @implementation S1AudioUnit {

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
@@ -12,7 +12,7 @@
 #import <vector>
 #import <list>
 #import <string>
-#import "AKSoundpipeKernel.hpp"
+#import "AudioKit/AKSoundpipeKernel.hpp"
 #import "S1AudioUnit.h"
 #import "S1Parameter.h"
 #import "S1Rate.hpp"

--- a/AudioKitSynthOne/DSP/Note State/S1NoteState.hpp
+++ b/AudioKitSynthOne/DSP/Note State/S1NoteState.hpp
@@ -12,7 +12,7 @@
 #import <vector>
 #import <list>
 #import <string>
-#import "AKSoundpipeKernel.hpp"
+#import "AudioKit/AKSoundpipeKernel.hpp"
 #import "S1AudioUnit.h"
 #import "S1Parameter.h"
 #import "S1Rate.hpp"

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,12 @@
 platform :ios, '9.0'
 use_frameworks!
 
+# This enables the cutting-edge staging builds of AudioKit, comment this line to stick to stable releases
+#source 'https://github.com/AudioKit/Specs.git'
+source 'https://github.com/CocoaPods/Specs.git'
+
 def available_pods
+    pod 'AudioKit'
     pod 'Disk', '~> 0.3.2'
     pod 'Audiobus'
     pod 'ChimpKit'
@@ -14,4 +19,5 @@ end
 
 target 'OneSignalNotificationServiceExtension' do
   pod 'OneSignal', '>= 2.6.2', '< 3.0'
+  pod 'AudioKit'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,15 @@
 PODS:
   - Audiobus (3.0.5)
+  - AudioKit (4.3):
+    - AudioKit/UI (= 4.3)
+  - AudioKit/UI (4.3)
   - ChimpKit (3.1.1)
   - Disk (0.3.3)
   - OneSignal (2.8.5)
 
 DEPENDENCIES:
   - Audiobus
+  - AudioKit
   - ChimpKit
   - Disk (~> 0.3.2)
   - OneSignal (< 3.0, >= 2.6.2)
@@ -13,16 +17,18 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - Audiobus
+    - AudioKit
     - ChimpKit
     - Disk
     - OneSignal
 
 SPEC CHECKSUMS:
   Audiobus: 7e25081005aed75e8170ad3f5a904acf90e1d73b
+  AudioKit: 95bd2427c1afa7954d71b0c6195a09b87b7448bc
   ChimpKit: d020126089544daa349397a91f1489a3f271b791
   Disk: d1f55cd61f6ca20f368232d0c6e37e3c3dfcb63e
   OneSignal: 42dae269c7eca517aee34963820e1eb922390031
 
-PODFILE CHECKSUM: 02340e67961c3d97925d5cda9de943715d0728f4
+PODFILE CHECKSUM: d20dee95025905fdc2e527b4771e23f416dec9b1
 
 COCOAPODS: 1.5.3

--- a/README.md
+++ b/README.md
@@ -17,14 +17,12 @@ The two primary branches of this repository are intended to be used as follows:
 
 ## Installation
 
-Currently you must checkout the git repository for AudioKit parallel in folder structure to this repo.
-Then, you must go into AudioKit's `Frameworks` folder and run `./build-frameworks.sh`.
-This may change to a Cocoapods-based structure eventually.
-
 You must install the pods that we depend on before you can compile the project. To do so, run the following at the root of the project:
 
-`pod repo update`
-`pod install`
+* `pod repo update`
+* `pod install`
+
+You may uncomment the line in `Podfile` to switch to our cutting-edge staging (unstable) releases of AudioKit, as opposed to the stable releases in the mainstream CocoaPods specs.
 
 ## Documentation
 
@@ -34,19 +32,18 @@ any hints about what could be improved.
 
 ### This folder's contents
 
-* AudioKitSynthOne/ - This folder contains most of the source code
-* AudioKitSynthOne.xcodeproj - This file is a part of the workspace, which you should open instead
-* AudioKitSynthOne.xcworkspace - This is the file you should open with Xcode, it contains reference to both the project files for the synth code and associated Pods
-* OneSignalNotificationServiceExtension/ - code for a third party extension we use
-* Podfile and Podfile.lock - Cocoapods configuration files
-* .swiftlint.yml - Swiftlint configuration
+* `AudioKitSynthOne/` - This folder contains most of the source code
+* `AudioKitSynthOne.xcodeproj` - This file is a part of the workspace, which you should open instead
+* `AudioKitSynthOne.xcworkspace` - This is the file you should open with Xcode, it contains reference to both the project files for the synth code and associated Pods
+* `OneSignalNotificationServiceExtension/` - code for a third party extension we use
+* `Podfile` and `Podfile.lock` - Cocoapods configuration files
+* `.swiftlint.yml` - Swiftlint configuration
 
 ## Opportunities for Contributing
 
 Here's a few ideas for you to contribute to this historic project:
 
 * Write a PDF Manual. We can help answer any questions. Write a manual for Synth One in your language. 
-
 
 * Have AUv3 development experience? Help with the AUv3 version! (Plus, we have a  Slack Channel for this topic)
 
@@ -61,6 +58,8 @@ Here's a few ideas for you to contribute to this historic project:
 * Add a trance/rhythm gate panel
 
 * Add a side chain/volume ducking panel
+
+* Localizations
 
 
 If you have audio development experience and want to be more involved with Synth One, please email [hello@audiokitpro.com](mailto:hello@audiokitpro.com)


### PR DESCRIPTION
Made the necessary changes to make this a 100% CocoaPods-based project. This will make it a lot easier for people to get started as all they have to do is download the project and do a `pod install` to get started.

It also makes it easy to switch to the staging builds of AudioKit just by uncommenting a line in the `Podfile`. In turn we can push new features as needed to the staging branch to trigger new builds.

As of right now it seems to compile with either 4.3 or the code in `devel` so I'm leaving it to the mainstream release as a default for now.
