### PR TITLE
"What You Hear Is What You Save". WYHIWYS

### DIFF
--- a/AudioKitSynthOne/Developer/Dev.storyboard
+++ b/AudioKitSynthOne/Developer/Dev.storyboard
@@ -188,12 +188,12 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="geG-Iv-YXF" customClass="Knob" customModule="AudioKitSynthOne" customModuleProvider="target">
-                                <rect key="frame" x="726" y="31" width="50" height="50"/>
+                                <rect key="frame" x="845" y="31" width="50" height="50"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="DSP Param Halftime" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="slc-Pi-ahg">
-                                <rect key="frame" x="721" y="83" width="60" height="47"/>
+                                <rect key="frame" x="840" y="82" width="60" height="47"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" name="AvenirNextCondensed-Regular" family="Avenir Next Condensed" pointSize="15"/>
                                 <color key="textColor" red="0.73333333329999995" green="0.73333333329999995" blue="0.73333333329999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -248,6 +248,18 @@
                                 <color key="textColor" red="0.13725490200000001" green="0.14117647059999999" blue="0.1333333333" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Lock Arp+Seq" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ct1-IH-Yiw" userLabel="Lock Arp/Seq">
+                                <rect key="frame" x="716" y="72" width="70" height="37"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" name="AvenirNextCondensed-Regular" family="Avenir Next Condensed" pointSize="13"/>
+                                <color key="textColor" red="0.73333333329999995" green="0.73333333329999995" blue="0.73333333329999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mwm-fx-zig" userLabel="Lock Arp/Seq" customClass="ToggleButton" customModule="AudioKitSynthOne" customModuleProvider="target">
+                                <rect key="frame" x="734" y="41" width="34" height="36"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" red="0.21176470589999999" green="0.20784313730000001" blue="0.2156862745" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <viewLayoutGuide key="safeArea" id="kf6-vc-yZB"/>
@@ -275,6 +287,7 @@
                         <outlet property="delayInputFilterCutoffFreqTrackingRatio" destination="gi9-Wu-alZ" id="Qt6-SQ-uPP"/>
                         <outlet property="delayInputFilterResonance" destination="8NL-71-pZV" id="9Ge-uT-1uJ"/>
                         <outlet property="freezeArpRate" destination="8h5-8l-ANW" id="Ojt-7O-Jq8"/>
+                        <outlet property="freezeArpSeq" destination="mwm-fx-zig" id="fFg-7N-w26"/>
                         <outlet property="freezeDelay" destination="zt4-Er-3QI" id="msm-IJ-vp0"/>
                         <outlet property="freezeReverb" destination="61c-fK-kgF" id="R2e-ED-HwI"/>
                         <outlet property="masterVolume" destination="dty-uU-oTK" id="ezH-mp-Y2r"/>
@@ -283,7 +296,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4dw-L5-b47" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="66.796875" y="137.890625"/>
+            <point key="canvasLocation" x="65.599999999999994" y="137.18140929535232"/>
         </scene>
     </scenes>
     <resources>

--- a/AudioKitSynthOne/Developer/DevViewController.swift
+++ b/AudioKitSynthOne/Developer/DevViewController.swift
@@ -137,5 +137,10 @@ class DevViewController: UpdatableViewController {
         portamento.callback = { value in
             self.delegate?.portamentoChanged(value)
         }
+
+        // todo: freeze arp on
+
+        // todo: freeze arp is sequencer and sequence
+        
     }
 }

--- a/AudioKitSynthOne/Developer/DevViewController.swift
+++ b/AudioKitSynthOne/Developer/DevViewController.swift
@@ -13,6 +13,7 @@ protocol DevViewDelegate: AnyObject {
     func freezeArpRateChanged(_ value: Bool)
     func freezeReverbChanged(_ value: Bool)
     func freezeDelayChanged(_ value: Bool)
+    func freezeArpSeqChanged(_ value: Bool)
     func portamentoChanged(_ value: Double)
 }
 
@@ -51,6 +52,8 @@ class DevViewController: UpdatableViewController {
     var freezeReverbValue = false
     @IBOutlet weak var freezeDelay: ToggleButton!
     var freezeDelayValue = false
+    @IBOutlet weak var freezeArpSeq: ToggleButton!
+    var freezeArpSeqValue = false
 
     @IBOutlet weak var portamento: Knob!
     var portamentoHalfTime = 0.1
@@ -131,16 +134,26 @@ class DevViewController: UpdatableViewController {
             self.delegate?.freezeReverbChanged(value == 1 ? true : false)
         }
 
+        // freeze arp+sequencer: ignore Preset updates for the following parameters:
+        // arpIsOn
+        // arpIsSequencer
+        // arpDirection
+        // arpInterval
+        // arpOctave
+        // arpTotalSteps
+        // sequencerPattern00, ..., sequencerPattern15
+        // sequencerOctBoost00, ..., sequencerOctBoost15
+        // sequencerNoteOn00, ..., sequencerNoteOn15
+        freezeArpSeq.value = freezeArpSeqValue ? 1 : 0
+        freezeArpSeq.callback = { value in
+            self.delegate?.freezeArpSeqChanged(value == 1 ? true : false)
+        }
+
         // portamentoHalfTime (dsp parameter stored in app settings not presets)
         portamento.range = s.getRange(.portamentoHalfTime)
         portamento.value = portamentoHalfTime
         portamento.callback = { value in
             self.delegate?.portamentoChanged(value)
         }
-
-        // todo: freeze arp on
-
-        // todo: freeze arp is sequencer and sequence
-        
     }
 }

--- a/AudioKitSynthOne/Developer/Manager+DevView.swift
+++ b/AudioKitSynthOne/Developer/Manager+DevView.swift
@@ -33,6 +33,11 @@ extension Manager: DevViewDelegate {
         Conductor.sharedInstance.updateDisplayLabel("Freeze Delay: \(value == false ? "false" : "true")")
     }
 
+    func freezeArpSeqChanged(_ value: Bool) {
+        appSettings.freezeArpSeq = value
+        Conductor.sharedInstance.updateDisplayLabel("Freeze Arp+Sequencer: \(value == false ? "false" : "true")")
+    }
+
     func portamentoChanged(_ value: Double) {
         appSettings.portamentoHalfTime = value
         Conductor.sharedInstance.updateDisplayLabel("dsp smoothing half time: \(value.decimalString)")

--- a/AudioKitSynthOne/Developer/README.md
+++ b/AudioKitSynthOne/Developer/README.md
@@ -22,8 +22,18 @@ Settings (stored in settings, not saved with presets):
 
 LockArpRate: OFF by default.  When enabled: loading a preset will ignore the preset's tempo.  This is great for when you want to jam at a constant tempo and blaze through presets.  When we add tempo sync (i.e., Ableton Link) we might have to change how this works.
 
-LockReverb: OFF by default: When enabled: Loading a preset will ignore the preset's reverb settings.  I like to use this when I want to record a dry signal.
+LockReverb: OFF by default: When enabled: Loading a preset will ignore the preset's reverb parameters in favor of the current parameters.
 
-LockDelay: OFF by default: When enabled: Loading a preset will ignore the preset's delay settings.
+LockDelay: OFF by default: When enabled: Loading a preset will ignore the preset's delay parameters in favor of the current parameters.
 
+Lock Arp+Seq: OFF by default.  When enabled: Loading a preset will ignore the preset's following parameters:
+arpIsOn
+arpIsSequencer
+arpDirection
+arpInterval
+arpOctave
+arpTotalSteps
+sequencerPattern00, ..., sequencerPattern15
+sequencerOctBoost00, ..., sequencerOctBoost15
+sequencerNoteOn00, ..., sequencerNoteOn15
 

--- a/AudioKitSynthOne/Presets/PresetDataManager.swift
+++ b/AudioKitSynthOne/Presets/PresetDataManager.swift
@@ -19,10 +19,12 @@ extension Manager {
             return
         }
 
-        s.setSynthParameter(.tempoSyncToArpRate, activePreset.tempoSyncToArpRate)
+        // The DEV panel has toggles (stored in settings) that impact loading of subsets of parameters of a Preset
+
         if !appSettings.freezeArpRate {
             s.setSynthParameter(.arpRate, activePreset.arpRate)
         }
+
         if !appSettings.freezeDelay {
             s.setSynthParameter(.delayOn, activePreset.delayToggled)
             s.setSynthParameter(.delayFeedback, activePreset.delayFeedback)
@@ -31,12 +33,32 @@ extension Manager {
             s.setSynthParameter(.delayInputCutoffTrackingRatio, activePreset.delayInputCutoffTrackingRatio)
             s.setSynthParameter(.delayInputResonance, activePreset.delayInputResonance)
         }
+
         if !appSettings.freezeReverb {
             s.setSynthParameter(.reverbOn, activePreset.reverbToggled)
             s.setSynthParameter(.reverbFeedback, activePreset.reverbFeedback)
             s.setSynthParameter(.reverbHighPass, activePreset.reverbHighPass)
             s.setSynthParameter(.reverbMix, activePreset.reverbMix)
         }
+
+        if !appSettings.freezeArpSeq {
+            s.setSynthParameter(.arpIsOn, activePreset.isArpMode)
+            s.setSynthParameter(.arpIsSequencer, activePreset.arpIsSequencer ? 1 : 0 )
+            for i in 0..<16 {
+                s.setPattern(forIndex: i, activePreset.seqPatternNote[i])
+                s.setOctaveBoost(forIndex: i, activePreset.seqOctBoost[i] ? 1 : 0)
+                s.setNoteOn(forIndex: i, activePreset.seqNoteOn[i])
+            }
+        }
+
+        if appSettings.saveTuningWithPreset {
+            if let m = activePreset.tuningMasterSet {
+                tuningsPanel.setTuning(name: activePreset.tuningName, masterArray: m)
+            } else {
+                tuningsPanel.setDefaultTuning()
+            }
+        }
+
         s.setSynthParameter(.tempoSyncToArpRate, activePreset.tempoSyncToArpRate)
         s.setSynthParameter(.lfo1Rate, activePreset.lfoRate)
         s.setSynthParameter(.lfo2Rate, activePreset.lfo2Rate)
@@ -98,20 +120,13 @@ extension Manager {
         s.setSynthParameter(.tremoloLFO, activePreset.tremoloLFO)
         s.setSynthParameter(.arpDirection, activePreset.arpDirection)
         s.setSynthParameter(.arpInterval, activePreset.arpInterval)
-        s.setSynthParameter(.arpIsOn, activePreset.isArpMode)
         s.setSynthParameter(.arpOctave, activePreset.arpOctave)
-        s.setSynthParameter(.arpIsSequencer, activePreset.arpIsSequencer ? 1 : 0 )
         s.setSynthParameter(.arpTotalSteps, activePreset.arpTotalSteps )
         s.setSynthParameter(.monoIsLegato, activePreset.isLegato )
         s.setSynthParameter(.phaserMix, activePreset.phaserMix)
         s.setSynthParameter(.phaserRate, activePreset.phaserRate)
         s.setSynthParameter(.phaserFeedback, activePreset.phaserFeedback)
         s.setSynthParameter(.phaserNotchWidth, activePreset.phaserNotchWidth)
-        for i in 0..<16 {
-            s.setPattern(forIndex: i, activePreset.seqPatternNote[i])
-            s.setOctaveBoost(forIndex: i, activePreset.seqOctBoost[i] ? 1 : 0)
-            s.setNoteOn(forIndex: i, activePreset.seqNoteOn[i])
-        }
         s.setSynthParameter(.filterType, activePreset.filterType)
         s.setSynthParameter(.compressorMasterRatio, activePreset.compressorMasterRatio)
         s.setSynthParameter(.compressorReverbInputRatio, activePreset.compressorReverbInputRatio)
@@ -132,15 +147,7 @@ extension Manager {
         s.setSynthParameter(.delayInputResonance, activePreset.delayInputResonance)
         s.setSynthParameter(.pitchbendMinSemitones, activePreset.pitchbendMinSemitones)
         s.setSynthParameter(.pitchbendMaxSemitones, activePreset.pitchbendMaxSemitones)
-
         s.setSynthParameter(.frequencyA4, activePreset.frequencyA4)
-        if appSettings.saveTuningWithPreset {
-            if let m = activePreset.tuningMasterSet {
-                tuningsPanel.setTuning(name: activePreset.tuningName, masterArray: m)
-            } else {
-                tuningsPanel.setDefaultTuning()
-            }
-        }
 
         s.resetSequencer()
     }
@@ -151,21 +158,15 @@ extension Manager {
             return
         }
 
-        if !appSettings.freezeArpRate {
-            activePreset.arpRate = s.getSynthParameter(.arpRate)
-        }
-        if !appSettings.freezeDelay {
-            activePreset.delayToggled = s.getSynthParameter(.delayOn)
-            activePreset.delayFeedback = s.getSynthParameter(.delayFeedback)
-            activePreset.delayTime = s.getSynthParameter(.delayTime)
-            activePreset.delayMix = s.getSynthParameter(.delayMix)
-        }
-        if !appSettings.freezeReverb {
-            activePreset.reverbToggled = s.getSynthParameter(.reverbOn)
-            activePreset.reverbFeedback = s.getSynthParameter(.reverbFeedback)
-            activePreset.reverbHighPass = s.getSynthParameter(.reverbHighPass)
-            activePreset.reverbMix = s.getSynthParameter(.reverbMix)
-        }
+        activePreset.arpRate = s.getSynthParameter(.arpRate)
+        activePreset.delayToggled = s.getSynthParameter(.delayOn)
+        activePreset.delayFeedback = s.getSynthParameter(.delayFeedback)
+        activePreset.delayTime = s.getSynthParameter(.delayTime)
+        activePreset.delayMix = s.getSynthParameter(.delayMix)
+        activePreset.reverbToggled = s.getSynthParameter(.reverbOn)
+        activePreset.reverbFeedback = s.getSynthParameter(.reverbFeedback)
+        activePreset.reverbHighPass = s.getSynthParameter(.reverbHighPass)
+        activePreset.reverbMix = s.getSynthParameter(.reverbMix)
         activePreset.tempoSyncToArpRate = s.getSynthParameter(.tempoSyncToArpRate)
         activePreset.masterVolume = s.getSynthParameter(.masterVolume)
         activePreset.isMono = s.getSynthParameter(.isMono)

--- a/AudioKitSynthOne/Settings/AppSettings.swift
+++ b/AudioKitSynthOne/Settings/AppSettings.swift
@@ -31,8 +31,9 @@ class AppSettings: Codable {
     var plotFilled = true
     var velocitySensitive = false
     var freezeArpRate = false // true = don't modify when preset changes
-    var freezeDelay = false // true = don't modify when preset changes
-    var freezeReverb = false // true = don't modify when preset changes
+    var freezeDelay = false // true = don't modify current delay parameters when preset changes
+    var freezeReverb = false // true = don't modify current reverb parameters when preset changes
+    var freezeArpSeq = false // true = don't modify current arp+seq parameters when preset changes
     var portamentoHalfTime = 0.1 // global portamento HALFTIME for dsp params that are smoothed
 
     //Settings: "Save Tuning Panel w/Presets" -> saveTuningWithPreset = True/False
@@ -130,6 +131,7 @@ class AppSettings: Codable {
         freezeArpRate = dictionary["freezeArpRate"] as? Bool ?? freezeArpRate
         freezeDelay = dictionary["freezeDelay"] as? Bool ?? freezeDelay
         freezeReverb = dictionary["freezeReverb"] as? Bool ?? freezeReverb
+        freezeArpSeq = dictionary["freezeArpSeq"] as? Bool ?? freezeArpSeq
         saveTuningWithPreset = dictionary["saveTuningWithPreset"] as? Bool ?? saveTuningWithPreset
         presetsVersion = dictionary["presetsVersion"] as? Double ?? presetsVersion
 


### PR DESCRIPTION
Added freezing for arp+sequencer in the DEV panel.
This PR will:
When loading a preset ignore the preset's arp+sequencer parameters if the freeze arp+sequencer app setting is true.
When saving a preset: will capture the current dsp parameters regardless of "freezing" status so that what you hear is what you save.
Clarify this behavior in the documentation.