### PR TITLE
Smooth Delay Changes

### DIFF
--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
@@ -375,7 +375,7 @@ private:
         { reverbMix,             0, 0, 1, "reverbMix", "reverbMix", kAudioUnitParameterUnit_Generic, true, NULL},
         { delayOn,               0, 0, 1, "delayOn", "delayOn", kAudioUnitParameterUnit_Generic, true, NULL},
         { delayFeedback,         0, 0.1, 0.9, "delayFeedback", "delayFeedback", kAudioUnitParameterUnit_Generic, true, NULL},
-        { delayTime,             0.0003628117914, 0.25, 2.5, "delayTime", "delayTime", kAudioUnitParameterUnit_Seconds, false, NULL},
+        { delayTime,             0.0003628117914, 0.25, 2.5, "delayTime", "delayTime", kAudioUnitParameterUnit_Seconds, true, NULL},
         { delayMix,              0, 0.125, 1, "delayMix", "delayMix", kAudioUnitParameterUnit_Generic, true, NULL},
         { lfo2Index,             0, 0, 3, "lfo2Index", "lfo2Index", kAudioUnitParameterUnit_Generic, false, NULL},
         { lfo2Amplitude,         0, 0, 1, "lfo2Amplitude", "lfo2Amplitude", kAudioUnitParameterUnit_Generic, true, NULL},


### PR DESCRIPTION
Previously Delay Changes coming in from the model would not be smoothed
when updated in the process block, thus resulting in loud clicks.
This would occur not only when changing the delay itself, but also in case of tempo-sync (and with tempo changes propagated through MIDI Sync or Link).

Smoothing the delay time gives it a more analogue feel on changes and gets rid of the
click. (Implementing a fade on changes might require more work, potentially touching the Soundpipe Lib itself) 

I'm not sure if this was a conscious decision or an oversight, happy to close this if it was on purpose.