### PR TITLE
Double Tap to Default

### DIFF
--- a/AudioKitSynthOne/Controls/Buttons/SynthButton.swift
+++ b/AudioKitSynthOne/Controls/Buttons/SynthButton.swift
@@ -11,6 +11,7 @@ import UIKit
 class SynthButton: UIButton, S1Control {
 
     var callback: (Double) -> Void = { _ in }
+    var defaultCallback: () -> Void = { }
 
     var isOn: Bool {
         return value == 1

--- a/AudioKitSynthOne/Controls/Buttons/ToggleButton.swift
+++ b/AudioKitSynthOne/Controls/Buttons/ToggleButton.swift
@@ -18,6 +18,7 @@ class ToggleButton: UIView, S1Control {
     }
 
     var callback: (Double) -> Void = { _ in }
+    var defaultCallback: () -> Void = { }
 
     var value: Double = 0.0 {
         didSet {

--- a/AudioKitSynthOne/Controls/Buttons/ToggleSwitch.swift
+++ b/AudioKitSynthOne/Controls/Buttons/ToggleSwitch.swift
@@ -27,6 +27,7 @@ class ToggleSwitch: UIView, S1Control {
         }
     }
     public var callback: (Double) -> Void = { _ in }
+    var defaultCallback: () -> Void = { }
 
     override func draw(_ rect: CGRect) {
         ToggleSwitchStyleKit.drawToggleSwitch(isToggled: value == 0 ? false : true )

--- a/AudioKitSynthOne/Controls/Knobs/Knob.swift
+++ b/AudioKitSynthOne/Controls/Knobs/Knob.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @IBDesignable
-public class Knob: UIView, S1Control {
+public class Knob: UIView, UIGestureRecognizerDelegate, S1Control {
 
     var onlyIntegers: Bool = false
 
@@ -83,6 +83,11 @@ public class Knob: UIView, S1Control {
         super.init(coder: coder)
         self.isUserInteractionEnabled = true
         contentMode = .redraw
+
+        let doubleTapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
+        doubleTapGesture.delegate = self
+        doubleTapGesture.numberOfTapsRequired = 2
+        addGestureRecognizer(doubleTapGesture)
     }
 
     override public func prepareForInterfaceBuilder() {
@@ -102,6 +107,10 @@ public class Knob: UIView, S1Control {
                                                width: self.bounds.width,
                                                height: self.bounds.height),
                                  knobValue: knobValue)
+    }
+
+    @objc public func handleTap(_ sender: Knob) {
+        defaultCallback()
     }
 
     // Helper

--- a/AudioKitSynthOne/Controls/Knobs/Knob.swift
+++ b/AudioKitSynthOne/Controls/Knobs/Knob.swift
@@ -14,6 +14,7 @@ public class Knob: UIView, S1Control {
     var onlyIntegers: Bool = false
 
     var callback: (Double) -> Void = { _ in }
+    var defaultCallback: () -> Void = { }
 
     public var taper: Double = 1.0 // Linear by default
 

--- a/AudioKitSynthOne/Controls/Stepper/Stepper.swift
+++ b/AudioKitSynthOne/Controls/Stepper/Stepper.swift
@@ -12,6 +12,7 @@ import UIKit
 class Stepper: UIView, S1Control {
 
     public var callback: (Double) -> Void = { _ in }
+    var defaultCallback: () -> Void = { }
 
     var minusPath = UIBezierPath(roundedRect: CGRect(x: 0.5, y: 2, width: 35, height: 32), cornerRadius: 1)
     var plusPath = UIBezierPath(roundedRect: CGRect(x: 70.5, y: 2, width: 35, height: 32), cornerRadius: 1)

--- a/AudioKitSynthOne/DSP/Conductor.swift
+++ b/AudioKitSynthOne/DSP/Conductor.swift
@@ -11,6 +11,7 @@ import AudioKit
 protocol S1Control: class {
     var value: Double { get set }
     var callback: (Double) -> Void { get set }
+    var defaultCallback: () -> Void { get set }
 }
 
 typealias S1ControlCallback = (S1Parameter, S1Control?) -> ((_: Double) -> Void)

--- a/AudioKitSynthOne/Effects/UI Components/LFOToggle.swift
+++ b/AudioKitSynthOne/Effects/UI Components/LFOToggle.swift
@@ -12,6 +12,7 @@ import UIKit
 class LFOToggle: UIView, S1Control {
 
     var callback: (Double) -> Void = { _ in }
+    var defaultCallback: () -> Void = { }
     var value: Double = 0 {
         didSet {
             // Code for activating LFO state from Preset load

--- a/AudioKitSynthOne/Effects/UI Components/LFOWavePicker.swift
+++ b/AudioKitSynthOne/Effects/UI Components/LFOWavePicker.swift
@@ -12,6 +12,7 @@ import UIKit
 class LFOWavePicker: UIView, S1Control {
 
     var callback: (Double) -> Void = { _ in }
+    var defaultCallback: () -> Void = { }
     var value: Double = 0 {
         didSet {
            setNeedsDisplay()

--- a/AudioKitSynthOne/Generators/UI Components/FilterTypeButton.swift
+++ b/AudioKitSynthOne/Generators/UI Components/FilterTypeButton.swift
@@ -11,6 +11,7 @@ import UIKit
 class FilterTypeButton: UIButton, S1Control {
 
     var callback: (Double) -> Void = { _ in }
+    var defaultCallback: () -> Void = { }
 
     private var _value: Double = 0 {
         didSet {

--- a/AudioKitSynthOne/Generators/UI Components/FilterTypeButton.swift
+++ b/AudioKitSynthOne/Generators/UI Components/FilterTypeButton.swift
@@ -12,24 +12,24 @@ class FilterTypeButton: UIButton, S1Control {
 
     var callback: (Double) -> Void = { _ in }
 
-	private var _value: Double = 0 {
-		didSet {
-			switch _value {
-			case 0:
-				// low pass
-				accessibilityValue = NSLocalizedString("Low Pass", comment: "Low Pass")
-			case 1:
-				// band pass
-				accessibilityValue = NSLocalizedString("Band Pass", comment: "Low Pass")
-			case 2:
-				// high pass
-				accessibilityValue = NSLocalizedString("High Pass", comment: "Low Pass")
-			default:
-				// low pass
-				accessibilityValue = NSLocalizedString("Low Pass", comment: "Low Pass")
-			}
-		}
-	}
+    private var _value: Double = 0 {
+        didSet {
+            switch _value {
+            case 0:
+                // low pass
+                accessibilityValue = NSLocalizedString("Low Pass", comment: "Low Pass")
+            case 1:
+                // band pass
+                accessibilityValue = NSLocalizedString("Band Pass", comment: "Low Pass")
+            case 2:
+                // high pass
+                accessibilityValue = NSLocalizedString("High Pass", comment: "Low Pass")
+            default:
+                // low pass
+                accessibilityValue = NSLocalizedString("Low Pass", comment: "Low Pass")
+            }
+      }
+    }
 
     var value: Double {
         get {

--- a/AudioKitSynthOne/Generators/UI Components/MorphSelector.swift
+++ b/AudioKitSynthOne/Generators/UI Components/MorphSelector.swift
@@ -13,6 +13,7 @@ import UIKit
 class MorphSelector: UIView, S1Control {
 
     var callback: (Double) -> Void = { _ in }
+    var defaultCallback: () -> Void = { }
 
     var value: Double = 0 {
         didSet {

--- a/AudioKitSynthOne/Generators/UI Components/MorphSelector.swift
+++ b/AudioKitSynthOne/Generators/UI Components/MorphSelector.swift
@@ -14,28 +14,28 @@ class MorphSelector: UIView, S1Control {
 
     var callback: (Double) -> Void = { _ in }
 
-	var value: Double = 0 {
-		didSet {
-			if value < 0.0 { value = 0.0 }
-			if value > 1.0 { value = 1.0 }
-			setNeedsDisplay()
+    var value: Double = 0 {
+        didSet {
+            if value < 0.0 { value = 0.0 }
+            if value > 1.0 { value = 1.0 }
+            setNeedsDisplay()
 
-			let valueAsString = String(format: "%.2f", value)
+            let valueAsString = String(format: "%.2f", value)
 
-			switch valueAsString {
-			case "0.00":
-				accessibilityValue = valueAsString + NSLocalizedString(", Pure Triangle Wave", comment: ", Pure Triangle Wave")
-			case "0.33":
-				accessibilityValue = valueAsString + NSLocalizedString(", Pulse 50% Wave", comment: ", Pulse 50% Wave")
-			case "0.66":
-				accessibilityValue = valueAsString + NSLocalizedString(", Pulse 10% Wave", comment: ", Pulse 10% Wave")
-			case "1.00":
-				accessibilityValue = valueAsString + NSLocalizedString(", Pure Saw Wave", comment: ", Pure Saw Wave")
-			default:
-				accessibilityValue = valueAsString
-			}
-		}
-	}
+            switch valueAsString {
+                case "0.00":
+                    accessibilityValue = valueAsString + NSLocalizedString(", Pure Triangle Wave", comment: ", Pure Triangle Wave")
+                case "0.33":
+                    accessibilityValue = valueAsString + NSLocalizedString(", Pulse 50% Wave", comment: ", Pulse 50% Wave")
+                case "0.66":
+                    accessibilityValue = valueAsString + NSLocalizedString(", Pulse 10% Wave", comment: ", Pulse 10% Wave")
+                case "1.00":
+                    accessibilityValue = valueAsString + NSLocalizedString(", Pure Saw Wave", comment: ", Pure Saw Wave")
+                default:
+                    accessibilityValue = valueAsString
+            }
+        }
+    }
 
     //// Color Declarations
     @IBInspectable open var color: UIColor = #colorLiteral(red: 0.1333333333, green: 0.1333333333, blue: 0.1333333333, alpha: 1)
@@ -64,13 +64,13 @@ class MorphSelector: UIView, S1Control {
 		accessibilityInit()
     }
 
-	func accessibilityInit() {
-		accessibilityTraits = [
-			.adjustable,
-			.allowsDirectInteraction,
-			.updatesFrequently
-		]
-	}
+    func accessibilityInit() {
+        accessibilityTraits = [
+            .adjustable,
+            .allowsDirectInteraction,
+            .updatesFrequently
+        ]
+    }
 
     override open func draw(_ rect: CGRect) {
         MorphSelectorStyleKit.drawMorphSelector(value: CGFloat(value),
@@ -97,16 +97,16 @@ class MorphSelector: UIView, S1Control {
         setNeedsDisplay()
     }
 
-	override open func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-		UIAccessibility.post(notification: .announcement, argument: nil)
-	}
+    override open func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        UIAccessibility.post(notification: .announcement, argument: nil)
+    }
 
-	override func accessibilityIncrement() {
-		value += 0.01
-	}
+    override func accessibilityIncrement() {
+        value += 0.01
+    }
 
-	override func accessibilityDecrement() {
-		value -= 0.01
-	}
+    override func accessibilityDecrement() {
+        value -= 0.01
+    }
 
 }

--- a/AudioKitSynthOne/Presets/PresetDataManager.swift
+++ b/AudioKitSynthOne/Presets/PresetDataManager.swift
@@ -145,6 +145,7 @@ extension Manager {
         s.setSynthParameter(.adsrPitchTracking, activePreset.adsrPitchTracking)
 
         s.resetSequencer()
+        conductor.updateDefaultValues()
     }
 
     func saveValuesToPreset() {
@@ -281,5 +282,6 @@ extension Manager {
         activePreset.userText = presetsViewController.currentPreset.userText
 
         presetsViewController.savePreset(activePreset)
+        conductor.updateDefaultValues()
     }
 }

--- a/AudioKitSynthOne/Sequencer/UI Components/ArpButton.swift
+++ b/AudioKitSynthOne/Sequencer/UI Components/ArpButton.swift
@@ -13,13 +13,13 @@ class ArpButton: UIView, S1Control {
 
     // MARK: - ToggleButton
 
-	private var _value: Double = 0 {
-		didSet {
-			accessibilityValue = (_value == 1.0) ?
-				NSLocalizedString("On", comment: "On") :
-				NSLocalizedString("Off", comment: "Off")
-		}
-	}
+    private var _value: Double = 0 {
+        didSet {
+            accessibilityValue = (_value == 1.0) ?
+                NSLocalizedString("On", comment: "On") :
+                NSLocalizedString("Off", comment: "Off")
+        }
+    }
     var value: Double {
         get {
             return _value

--- a/AudioKitSynthOne/Sequencer/UI Components/ArpButton.swift
+++ b/AudioKitSynthOne/Sequencer/UI Components/ArpButton.swift
@@ -35,6 +35,7 @@ class ArpButton: UIView, S1Control {
     }
 
     public var callback: (Double) -> Void = { _ in }
+    var defaultCallback: () -> Void = { }
 
     override func draw(_ rect: CGRect) {
         ArpButtonStyleKit.drawArpButton(frame: CGRect(x: 0,

--- a/AudioKitSynthOne/Sequencer/UI Components/ArpDirectionButton.swift
+++ b/AudioKitSynthOne/Sequencer/UI Components/ArpDirectionButton.swift
@@ -17,21 +17,21 @@ class ArpDirectionButton: UIView, S1Control {
 
     private var width: CGFloat = 35.0
 
-	var value = 0.0 {
-		didSet {
-			setNeedsDisplay()
+    var value = 0.0 {
+        didSet {
+            setNeedsDisplay()
 
-			switch value {
-			case 0.0:
-				accessibilityValue = NSLocalizedString("Up", comment: "Up")
-			case 1.0:
-				accessibilityValue = NSLocalizedString("Up Down", comment: "Up Down")
-			default:
-				accessibilityValue = NSLocalizedString("Down", comment: "Down")
-			}
+            switch value {
+            case 0.0:
+                accessibilityValue = NSLocalizedString("Up", comment: "Up")
+            case 1.0:
+                accessibilityValue = NSLocalizedString("Up Down", comment: "Up Down")
+            default:
+                accessibilityValue = NSLocalizedString("Down", comment: "Down")
+            }
 
-		}
-	}
+        }
+    }
 
     // Draw Button
     override func draw(_ rect: CGRect) {
@@ -59,13 +59,13 @@ class ArpDirectionButton: UIView, S1Control {
         }
     }
 
-	override func accessibilityActivate() -> Bool {
-		//perform desired action
-		if value < 2.0 {
-			value += 1.0
-		} else {
-			value = 0.0
-		}
-		return true
-	}
+    override func accessibilityActivate() -> Bool {
+        //perform desired action
+        if value < 2.0 {
+            value += 1.0
+        } else {
+            value = 0.0
+        }
+        return true
+    }
 }

--- a/AudioKitSynthOne/Sequencer/UI Components/ArpDirectionButton.swift
+++ b/AudioKitSynthOne/Sequencer/UI Components/ArpDirectionButton.swift
@@ -14,6 +14,7 @@ class ArpDirectionButton: UIView, S1Control {
     // MARK: - LFO Button
 
     public var callback: (Double) -> Void = { _ in }
+    var defaultCallback: () -> Void = {  }
 
     private var width: CGFloat = 35.0
 

--- a/AudioKitSynthOne/Sequencer/UI Components/SliderTransposeButton.swift
+++ b/AudioKitSynthOne/Sequencer/UI Components/SliderTransposeButton.swift
@@ -43,6 +43,7 @@ class SliderTransposeButton: UILabel, S1Control {
     }
 
     public var callback: (Double) -> Void = { _ in }
+    var defaultCallback: () -> Void = { }
 
     var isActive = false {
         didSet {

--- a/AudioKitSynthOne/Sequencer/UI Components/VerticalSlider.swift
+++ b/AudioKitSynthOne/Sequencer/UI Components/VerticalSlider.swift
@@ -11,6 +11,7 @@ import UIKit
 class VerticalSlider: UIControl, S1Control {
 
     var callback: (Double) -> Void = { _ in }
+    var defaultCallback: () -> Void = { }
     var minValue: CGFloat = 0.0
     var maxValue: CGFloat = 1.0
     var currentValue: CGFloat = 0.5 {

--- a/AudioKitSynthOne/TouchPad/UI Components/AKVerticalPad.swift
+++ b/AudioKitSynthOne/TouchPad/UI Components/AKVerticalPad.swift
@@ -142,6 +142,13 @@ public class AKVerticalPad: UIView {
 
 // This is just to suppress warnings when passing AKVerticalPad as a payload to DSP setter
 extension AKVerticalPad: S1Control {
+    var defaultCallback: () -> Void {
+        get {
+            return { }
+        }
+        set { }
+    }
+
     var value: Double {
         get {
             return verticalValue

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ any hints about what could be improved.
 Here's a few ideas for you to contribute to this historic project:
 
 * Ability to search presets
-* Double tap knobs to go to defaults
 * Midi Learn Matrix. Create a view that will allow users to easily change the MIDI Learn assignments.
 * Make TouchPads assignable 
 * Add an EQ Panel (8-band/16-band/etc)


### PR DESCRIPTION
Double tapping a knob will restore the default value as specified by the last loaded preset.
Each UI Element has a defaultCallback closure which will set the component to the default value when called.
A temporary copy of the synth parameters is made once a new preset has been loaded or the current one been saved.

ping @analogcode - git history is chronological, so review commit-by-commit should be possible.