### PR TITLE
Move teardown ops to deallocation

### DIFF
--- a/AudioKitSynthOne/DSP/Audio Unit/S1AudioUnit.mm
+++ b/AudioKitSynthOne/DSP/Audio Unit/S1AudioUnit.mm
@@ -175,9 +175,8 @@
         return NO;
     }
     _outputBusBuffer.allocateRenderResources(self.maximumFramesToRender);
-    if (self.musicalContextBlock) { _musicalContext = self.musicalContextBlock; } else _musicalContext = nil;
+    if (self.musicalContextBlock) { _musicalContext = self.musicalContextBlock; }
     auto parameters = _kernel.p;
-    _kernel.destroy();
     _kernel.init(self.outputBus.format.channelCount, self.outputBus.format.sampleRate);
     _kernel.reset();
     _kernel.restoreValues(parameters);
@@ -187,6 +186,8 @@
 - (void)deallocateRenderResources {
     _outputBusBuffer.deallocateRenderResources();
     [super deallocateRenderResources];
+    _musicalContext = nil;
+    _kernel.destroy();
 }
 
 - (AUInternalRenderBlock)internalRenderBlock {


### PR DESCRIPTION
As discussed on Slack:
Move kernel and context teardown from the render allocation
block to the deallocation block.

Tested this against the iPad Air 2 that would previously crash.

ping @analogcode @marcussatellite 