### PR TITLE
Remove malloc usage of NoteStates

### DIFF
--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+destroy.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+destroy.mm
@@ -42,8 +42,6 @@ void S1DSPKernel::destroy() {
     sp_compressor_destroy(&compressorReverbInputR);
     sp_compressor_destroy(&compressorReverbWetL);
     sp_compressor_destroy(&compressorReverbWetR);
-    free(noteStates);
-    free(monoNote);
 }
 
 

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+didChanges.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+didChanges.mm
@@ -41,7 +41,8 @@ void S1DSPKernel::playingNotesDidChange() {
         }
     } else {
         for(int i=0; i<S1_MAX_POLYPHONY; i++) {
-            aePlayingNotes.playingNotes[i] = {noteStates[i].rootNoteNumber, noteStates[i].transpose, noteStates[i].amp};
+            const auto& note = (*noteStates)[i];
+            aePlayingNotes.playingNotes[i] = {note.rootNoteNumber, note.transpose, note.amp};
         }
     }
     AEMessageQueuePerformSelectorOnMainThread(audioUnit->_messageQueue,

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+process.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+process.mm
@@ -51,7 +51,7 @@ void S1DSPKernel::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffer
         }
     } else {
         for(int i=0; i<polyphony; i++) {
-            S1NoteState& note = noteStates[i];
+            auto& note = (*noteStates)[i];
             if (note.stage == S1NoteState::stageRelease && note.amp < S1_RELEASE_AMPLITUDE_THRESHOLD) {
                 note.clear();
             }
@@ -328,7 +328,7 @@ void S1DSPKernel::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffer
                 monoNote->run(frameIndex, outL, outR);
         } else {
             for(int i=0; i<polyphony; i++) {
-                S1NoteState& note = noteStates[i];
+                S1NoteState& note = (*noteStates)[i];
                 if (note.rootNoteNumber != -1 && note.stage != S1NoteState::stageOff)
                     note.run(frameIndex, outL, outR);
             }

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+reset.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+reset.mm
@@ -24,7 +24,7 @@ void S1DSPKernel::resetDSP() {
     _setSynthParameter(arpIsOn, 0.f);
     monoNote->clear();
     for(int i =0; i < S1_MAX_POLYPHONY; i++)
-        noteStates[i].clear();
+        (*noteStates)[i].clear();
 
     sp_vdelay_reset(sp, delayL);
     sp_vdelay_reset(sp, delayR);
@@ -34,7 +34,7 @@ void S1DSPKernel::resetDSP() {
 
 void S1DSPKernel::reset() {
     for (int i = 0; i<S1_MAX_POLYPHONY; i++)
-        noteStates[i].clear();
+        (*noteStates)[i].clear();
     monoNote->clear();
     resetted = true;
     sp_vdelay_reset(sp, delayL);

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+setup.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+setup.mm
@@ -31,7 +31,7 @@ void S1DSPKernel::initializeNoteStates() {
         initializedNoteStates = true;
         // POLY INIT
         for (int i = 0; i < S1_MAX_POLYPHONY; i++) {
-            S1NoteState& state = noteStates[i];
+            S1NoteState& state = (*noteStates)[i];
             state.kernel = this;
             state.init();
             state.stage = S1NoteState::stageOff;

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+toggleKeys.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+toggleKeys.mm
@@ -52,7 +52,7 @@ void S1DSPKernel::turnOnKey(int noteNumber, int velocity, float frequency) {
         // Note Stealing: Is noteNumber already playing?
         int index = -1;
         for(int i = 0 ; i < polyphony; i++) {
-            if (noteStates[i].rootNoteNumber == noteNumber) {
+            if ((*noteStates)[i].rootNoteNumber == noteNumber) {
                 index = i;
                 break;
             }
@@ -64,7 +64,7 @@ void S1DSPKernel::turnOnKey(int noteNumber, int velocity, float frequency) {
             // noteNumber is not playing: search for non-playing notes (-1) starting with current index
             for(int i = 0; i < polyphony; i++) {
                 const int modIndex = (playingNoteStatesIndex + i) % polyphony;
-                if (noteStates[modIndex].rootNoteNumber == -1) {
+                if ((*noteStates)[modIndex].rootNoteNumber == -1) {
                     index = modIndex;
                     break;
                 }
@@ -80,7 +80,7 @@ void S1DSPKernel::turnOnKey(int noteNumber, int velocity, float frequency) {
         }
 
         // POLY: INIT NoteState
-        S1NoteState& note = noteStates[playingNoteStatesIndex];
+        S1NoteState& note = (*noteStates)[playingNoteStatesIndex];
         note.startNoteHelper(noteNumber, velocity, frequency);
     }
 
@@ -137,7 +137,7 @@ void S1DSPKernel::turnOffKey(int noteNumber) {
         // POLY:
         int index = -1;
         for(int i = 0; i < polyphony; i++) {
-            if (noteStates[i].rootNoteNumber == noteNumber) {
+            if ((*noteStates)[i].rootNoteNumber == noteNumber) {
                 index = i;
                 break;
             }
@@ -146,7 +146,7 @@ void S1DSPKernel::turnOffKey(int noteNumber) {
         if (index != -1) {
 
             // put NoteState into release
-            S1NoteState& note = noteStates[index];
+            S1NoteState& note = (*noteStates)[index];
             if (note.stage != S1NoteState::stageOff) {
                 note.stage = S1NoteState::stageRelease;
                 note.internalGate = 0;

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
@@ -36,6 +36,7 @@
 
 struct S1NoteState;
 using DSPParameters = std::array<float, S1Parameter::S1ParameterCount>;
+using NoteStateArray = std::array<S1NoteState, S1_MAX_POLYPHONY>;
 
 class S1DSPKernel : public AKSoundpipeKernel, public AKOutputBuffered {
 
@@ -264,10 +265,10 @@ private:
     };
     
     // array of struct S1NoteState of count MAX_POLYPHONY
-    S1NoteState* noteStates;
+    std::unique_ptr<NoteStateArray> noteStates;
     
     // monophonic: single instance of NoteState
-    S1NoteState* monoNote;
+    std::unique_ptr<S1NoteState> monoNote;
     
     bool initializedNoteStates = false;
     

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.mm
@@ -74,9 +74,9 @@ void S1DSPKernel::init(int _channels, double _sampleRate) {
     sp_delay_init(sp, widenDelay, 0.05f);
     widenDelay->feedback = 0.f;
 
-    noteStates = (S1NoteState*)malloc(S1_MAX_POLYPHONY * sizeof(S1NoteState));
+    noteStates = std::make_unique<NoteStateArray>();
 
-    monoNote = (S1NoteState*)malloc(sizeof(S1NoteState));
+    monoNote = std::make_unique<S1NoteState>();
 
     heldNoteNumbers = (NSMutableArray<NSNumber*>*)[NSMutableArray array];
     heldNoteNumbersAE = [[AEArray alloc] initWithCustomMapping:^void *(id item) {


### PR DESCRIPTION
Removing the use of malloc/free in favour of
automatic memory management via unique_ptr.

Even if the kernel gets initialized twice, unique_ptr
will delete the old instances.

ping @marcussatellite @analogcode 