### PR TITLE
Move Select Current Preset Outside of Setter

### DIFF
--- a/AudioKitSynthOne/Presets/PresetsViewController/Presets+CategoryDelegate.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/Presets+CategoryDelegate.swift
@@ -12,6 +12,7 @@ extension PresetsViewController: CategoryDelegate {
 
     func categoryDidChange(_ newCategoryIndex: Int) {
         categoryIndex = newCategoryIndex
+        selectCurrentPreset()
     }
 
     func bankShare() {

--- a/AudioKitSynthOne/Presets/PresetsViewController/Presets+LoadSaveManipulate.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/Presets+LoadSaveManipulate.swift
@@ -29,6 +29,7 @@ extension PresetsViewController {
         }
 
         updateCategoryTable()
+        selectCurrentPreset()
     }
 
     func sortPresets() {

--- a/AudioKitSynthOne/Presets/PresetsViewController/Presets+UITableViewDelegate.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/Presets+UITableViewDelegate.swift
@@ -47,6 +47,7 @@ extension PresetsViewController: UITableViewDelegate {
 
             // Save presets
             saveAllPresetsIn(currentPreset.bank)
+            selectCurrentPreset()
         }
     }
 

--- a/AudioKitSynthOne/Presets/PresetsViewController/PresetsViewController.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/PresetsViewController.swift
@@ -40,7 +40,6 @@ class PresetsViewController: UIViewController {
     var sortedPresets = [Preset]() {
         didSet {
             tableView.reloadData()
-            selectCurrentPreset()
         }
     }
 


### PR DESCRIPTION
This should be called manually when e.g. the category changes or
presets have been loaded.

Measurement of `func loadBanks()`
Before:
`Presets+LoadSaveManipulate.swift:loadBanks():34:Initializing presets: COMPLETE IN SEC:  3.9090490341186523 seconds`
After
`Presets+LoadSaveManipulate.swift:loadBanks():34:Initializing presets: COMPLETE IN SEC: 0.38115596771240234`

Resulting in a ~3.5s faster load times (in Debug)

ping @marcussatellite @analogcode 