### PR TITLE
Introduce ArpMode Enum

### DIFF
--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+process.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+process.mm
@@ -211,10 +211,11 @@ void S1DSPKernel::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffer
                             const int arpIntervalUp = p[arpInterval] * npof;
                             const int onOff = 1;
                             const int arpOctaves = (int)p[arpOctave] + 1;
+                            const auto arpMode = static_cast<ArpegiatorMode>(p[arpDirection]);
 
-                            if (p[arpDirection] == 0.f) {
+                            if (arpMode == ArpegiatorMode::Up) {
 
-                                // ARP Up
+                                // Up
                                 int index = 0;
                                 for (int octave = 0; octave < arpOctaves; octave++) {
                                     for (int i = 0; i < heldNotesCount; i++) {
@@ -227,9 +228,8 @@ void S1DSPKernel::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffer
                                         ++index;
                                     }
                                 }
-                            } else if (p[arpDirection] == 1.f) {
+                            } else if (arpMode == ArpegiatorMode::UpDown) {
 
-                                //ARP Up + Down
                                 //Up
                                 int index = 0;
                                 for (int octave = 0; octave < arpOctaves; octave++) {
@@ -259,7 +259,7 @@ void S1DSPKernel::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffer
                                         }
                                     }
                                 }
-                            } else if (p[arpDirection] == 2.f) {
+                            } else if (arpMode == ArpegiatorMode::Down) {
 
                                 // ARP Down
                                 int index = 0;

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
@@ -263,7 +263,14 @@ private:
         sp_port *portamento;
         float portamentoTarget;
     };
-    
+
+    // Arpegiator Modes
+    enum struct ArpegiatorMode : int {
+        Up = 0,
+        UpDown = 1,
+        Down = 2
+    };
+
     // array of struct S1NoteState of count MAX_POLYPHONY
     std::unique_ptr<NoteStateArray> noteStates;
     


### PR DESCRIPTION
Introduce an enum for Arpegiator modes to make
the different arp-modes a bit more readable in code.

ping @marcussatellite @analogcode 