### PR TITLE
Use RAII in C++ in DSP Kernel

### DIFF
--- a/AudioKitSynthOne.xcodeproj/project.pbxproj
+++ b/AudioKitSynthOne.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		5FAA47B316A5F659F440DAC9 /* Pods-AKS1Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AKS1Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AKS1Extension/Pods-AKS1Extension.debug.xcconfig"; sourceTree = "<group>"; };
 		69982DAB2230543B00281051 /* Sequencer */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Sequencer; sourceTree = "<group>"; };
 		69982DAD223056DA00281051 /* S1Sequencer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = S1Sequencer.mm; path = AudioKitSynthOne/DSP/Sequencer/S1Sequencer.mm; sourceTree = "<group>"; };
+		69E4E45622381DF90049F0EA /* S1DSPCompressor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = S1DSPCompressor.hpp; sourceTree = "<group>"; };
 		90231BFB16779C7C2CD6CB3F /* Pods-AKS1Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AKS1Extension.release.xcconfig"; path = "Pods/Target Support Files/Pods-AKS1Extension/Pods-AKS1Extension.release.xcconfig"; sourceTree = "<group>"; };
 		9405503A210556C20039F101 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
 		9405503B210556C80039F101 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/About.strings; sourceTree = "<group>"; };
@@ -993,6 +994,7 @@
 		C435C57520C530C900DAECCD /* Kernel */ = {
 			isa = PBXGroup;
 			children = (
+				69E4E45622381DF90049F0EA /* S1DSPCompressor.hpp */,
 				C435C57720C530C900DAECCD /* S1DSPKernel.hpp */,
 				C435C57620C530C900DAECCD /* S1DSPKernel.mm */,
 				C4B490E520C649D900FD565A /* S1DSPKernel+destroy.mm */,

--- a/AudioKitSynthOne/Audiobus/Manager+Audiobus.swift
+++ b/AudioKitSynthOne/Audiobus/Manager+Audiobus.swift
@@ -18,7 +18,7 @@ extension Manager: ABAudiobusControllerStateIODelegate {
             for event in events {
                 guard let channel = event.channel, event.channel == self.midiChannelIn || self.omniMode else { return }
 
-                if event.status == AKMIDIStatus.noteOn {
+                if event.status?.type == AKMIDIStatusType.noteOn {
                     guard let noteNumber = event.noteNumber else { return }
                     if event.internalData[2] == 0 {
                         self.sustainer.stop(noteNumber: noteNumber)
@@ -35,23 +35,23 @@ extension Manager: ABAudiobusControllerStateIODelegate {
                     }
                 }
 
-                if event.status == AKMIDIStatus.noteOff {
+                if event.status?.type == AKMIDIStatusType.noteOff {
                     guard let noteNumber = event.noteNumber else { return }
                     self.sustainer.stop(noteNumber: noteNumber)
                 }
 
-                if event.status == AKMIDIStatus.pitchWheel {
+                if event.status?.type == AKMIDIStatusType.pitchWheel {
                     let x = MIDIWord(event.internalData[1])
                     let y = MIDIWord(event.internalData[2]) << 7
                     self.receivedMIDIPitchWheel(y + x, channel: channel)
                 }
 
-                if event.status == AKMIDIStatus.programChange {
-                    self.receivedMIDIProgramChange(event.data1, channel: channel)
+                if event.status?.type == AKMIDIStatusType.programChange {
+                    self.receivedMIDIProgramChange(event.internalData[1], channel: channel)
                 }
 
-                if event.status == AKMIDIStatus.controllerChange {
-                    self.receivedMIDIController(event.data1, value: event.data2, channel: channel)
+                if event.status?.type == AKMIDIStatusType.controllerChange {
+                    self.receivedMIDIController(event.internalData[2], value: event.internalData[2], channel: channel)
                 }
             }
         }

--- a/AudioKitSynthOne/DSP/AKSynthOne.swift
+++ b/AudioKitSynthOne/DSP/AKSynthOne.swift
@@ -292,7 +292,7 @@ import AudioKit
     // MARK: - AKPolyphonic
 
     // Function to start, play, or activate the node at frequency
-    open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double) {
+    open override func play(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, frequency: Double, channel: MIDIChannel) {
         internalAU?.startNote(noteNumber, velocity: velocity, frequency: Float(frequency))
     }
 

--- a/AudioKitSynthOne/DSP/Audio Unit/S1AudioUnit.mm
+++ b/AudioKitSynthOne/DSP/Audio Unit/S1AudioUnit.mm
@@ -14,7 +14,7 @@
 
 @implementation S1AudioUnit {
     // C++ members need to be ivars; they would be copied on access if they were properties.
-    S1DSPKernel _kernel;
+    std::unique_ptr<S1DSPKernel> _kernel;
     BufferedOutputBus _outputBusBuffer;
     AUHostMusicalContextBlock _musicalContext;
 }
@@ -23,48 +23,48 @@
 @synthesize s1Delegate = _s1Delegate;
 
 - (float)getSynthParameter:(S1Parameter)param {
-    return _kernel.getSynthParameter(param);
+    return _kernel->getSynthParameter(param);
 }
 
 - (void)setSynthParameter:(S1Parameter)param value:(float)value {
-    _kernel.setSynthParameter(param, value);
+    _kernel->setSynthParameter(param, value);
 }
 
 - (float)getDependentParameter:(S1Parameter)param {
-    return _kernel.getDependentParameter(param);
+    return _kernel->getDependentParameter(param);
 }
 
 - (void)setDependentParameter:(S1Parameter)param value:(float)value payload:(int)payload {
-    _kernel.setDependentParameter(param, value, payload);
+    _kernel->setDependentParameter(param, value, payload);
 }
 
 ///auv3
 - (void)setParameter:(AUParameterAddress)address value:(AUValue)value {
-    _kernel.setSynthParameter((S1Parameter)address, value);
+    _kernel->setSynthParameter((S1Parameter)address, value);
 }
 
 ///auv3
 - (AUValue)getParameter:(AUParameterAddress)address {
-    return _kernel.getSynthParameter((S1Parameter)address);
+    return _kernel->getSynthParameter((S1Parameter)address);
 }
 
 - (float)getMinimum:(S1Parameter)param {
-    return _kernel.minimum(param);
+    return _kernel->minimum(param);
 }
 
 - (float)getMaximum:(S1Parameter)param {
-    return _kernel.maximum(param);
+    return _kernel->maximum(param);
 }
 
 - (float)getDefault:(S1Parameter)param {
-    return _kernel.defaultValue(param);
+    return _kernel->defaultValue(param);
 }
 
 ///Deprecated:calling this method to access even a single element of this array results in creating the entire array
 - (NSArray<NSNumber*> *)parameters {
     NSMutableArray *temp = [NSMutableArray arrayWithCapacity:S1Parameter::S1ParameterCount];
     for (int i = 0; i < S1Parameter::S1ParameterCount; i++) {
-        [temp setObject:[NSNumber numberWithFloat:_kernel.parameters[i]] atIndexedSubscript:i];
+        [temp setObject:[NSNumber numberWithFloat:_kernel->parameters[i]] atIndexedSubscript:i];
     }
     return [NSArray arrayWithArray:temp];
 }
@@ -75,53 +75,53 @@
     for (int i = 0; i < parameters.count; i++) {
         params[i] = [parameters[i] floatValue];
     }
-    _kernel.setParameters(params);
+    _kernel->setParameters(params);
 }
 
 - (void)resetSequencer {
-    _kernel.resetSequencer();
+    _kernel->resetSequencer();
 }
 
 - (BOOL)isSetUp {
-    return _kernel.resetted;
+    return _kernel->resetted;
 }
 
 - (void)stopNote:(uint8_t)note {
-    _kernel.stopNote(note);
+    _kernel->stopNote(note);
 }
 
 - (void)startNote:(uint8_t)note velocity:(uint8_t)velocity {
-    _kernel.startNote(note, velocity);
+    _kernel->startNote(note, velocity);
 }
 
 - (void)startNote:(uint8_t)note velocity:(uint8_t)velocity frequency:(float)frequency {
-    _kernel.startNote(note, velocity, frequency);
+    _kernel->startNote(note, velocity, frequency);
 }
 
 - (void)setupWaveform:(UInt32)tableIndex size:(int)size {
-    _kernel.setupWaveform(tableIndex, (uint32_t)size);
+    _kernel->setupWaveform(tableIndex, (uint32_t)size);
 }
 
 - (void)setWaveform:(UInt32)tableIndex withValue:(float)value atIndex:(UInt32)sampleIndex {
-    _kernel.setWaveformValue(tableIndex, sampleIndex, value);
+    _kernel->setWaveformValue(tableIndex, sampleIndex, value);
 }
 
 - (void)setBandlimitFrequency:(UInt32)blIndex withFrequency:(float)frequency {
-    _kernel.setBandlimitFrequency(blIndex, frequency);
+    _kernel->setBandlimitFrequency(blIndex, frequency);
 }
 
 - (void)reset {
-    _kernel.reset();
+    _kernel->reset();
 }
 
 ///Puts all notes in Release...a kinder, gentler "reset".
 - (void)stopAllNotes {
-    _kernel.stopAllNotes();
+    _kernel->stopAllNotes();
 }
 
 ///Resets DSP
 - (void)resetDSP {
-    _kernel.resetDSP();
+    _kernel->resetDSP();
 }
 
 
@@ -132,29 +132,29 @@
     self.rampDuration = AKSettings.rampDuration;
     self.defaultFormat = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:AKSettings.sampleRate
                                                                         channels:AKSettings.channelCount];
-    _kernel.init(self.defaultFormat.channelCount, self.defaultFormat.sampleRate);
+    _kernel = std::make_unique<S1DSPKernel>(self.defaultFormat.channelCount, self.defaultFormat.sampleRate);
     _outputBusBuffer.init(self.defaultFormat, 2);
     self.outputBus = _outputBusBuffer.bus;
     self.outputBusArray = [[AUAudioUnitBusArray alloc] initWithAudioUnit:self
                                                                  busType:AUAudioUnitBusTypeOutput
                                                                   busses:@[self.outputBus]];
-    _kernel.audioUnit = self;
-    __block S1DSPKernel *blockKernel = &_kernel;
+    _kernel->audioUnit = self;
+    __block S1DSPKernel *blockKernel = _kernel.get();
     
     // Create parameter tree
     AudioUnitParameterOptions flags = kAudioUnitParameterFlag_IsWritable | kAudioUnitParameterFlag_IsReadable;
     NSMutableArray<AUParameter*>* tree = [NSMutableArray array];
     for(NSInteger i = S1Parameter::index1; i < S1Parameter::S1ParameterCount; i++) {
         const S1Parameter p = (S1Parameter)i;
-        const AUValue minValue = _kernel.minimum(p);
-        const AUValue maxValue = _kernel.maximum(p);
-        const AUValue defaultValue = _kernel.defaultValue(p);
-        const AudioUnitParameterUnit unit = _kernel.parameterUnit(p);
-        NSString* friendlyName = [NSString stringWithCString:_kernel.cString(p) encoding:[NSString defaultCStringEncoding]];
-        NSString* keyName = [NSString stringWithCString:_kernel.presetKey(p).c_str() encoding:[NSString defaultCStringEncoding]];
+        const AUValue minValue = _kernel->minimum(p);
+        const AUValue maxValue = _kernel->maximum(p);
+        const AUValue defaultValue = _kernel->defaultValue(p);
+        const AudioUnitParameterUnit unit = _kernel->parameterUnit(p);
+        NSString* friendlyName = [NSString stringWithCString:_kernel->cString(p) encoding:[NSString defaultCStringEncoding]];
+        NSString* keyName = [NSString stringWithCString:_kernel->presetKey(p).c_str() encoding:[NSString defaultCStringEncoding]];
         AUParameter *param = [AUParameterTree createParameterWithIdentifier:keyName name:friendlyName address:p min:minValue max:maxValue unit:unit unitName:nil flags:flags valueStrings:nil dependentParameters:nil];
         param.value = defaultValue;
-        //_kernel.setSynthParameter(p, defaultValue);
+        //_kernel->setSynthParameter(p, defaultValue);
         [tree addObject:param];
     }
     
@@ -176,11 +176,11 @@
     }
     _outputBusBuffer.allocateRenderResources(self.maximumFramesToRender);
     if (self.musicalContextBlock) { _musicalContext = self.musicalContextBlock; }
-    auto parameters = _kernel.parameters;
-    _kernel.init(self.outputBus.format.channelCount, self.outputBus.format.sampleRate);
-    _kernel.reset();
-    _kernel.restoreValues(parameters);
-    _kernel.updateWavetableIncrementValuesForCurrentSampleRate();
+    auto parameters = _kernel->parameters;
+    _kernel->init(self.outputBus.format.channelCount, self.outputBus.format.sampleRate);
+    _kernel->reset();
+    _kernel->restoreValues(parameters);
+    _kernel->updateWavetableIncrementValuesForCurrentSampleRate();
     
     return YES;
 }
@@ -189,11 +189,11 @@
     _outputBusBuffer.deallocateRenderResources();
     [super deallocateRenderResources];
     _musicalContext = nil;
-    _kernel.destroy();
+    _kernel->destroy();
 }
 
 - (AUInternalRenderBlock)internalRenderBlock {
-    __block S1DSPKernel *state = &_kernel;
+    __block S1DSPKernel *state = _kernel.get();
     return ^AUAudioUnitStatus(
                               AudioUnitRenderActionFlags *actionFlags,
                               const AudioTimeStamp       *timestamp,
@@ -209,7 +209,7 @@
         if (self->_musicalContext) {
             if (self->_musicalContext( &currentTempo, NULL, NULL, NULL, NULL, NULL ) ) {
                 //TODO:AURE: midi clock
-                self->_kernel.handleTempoSetting(currentTempo);
+                self->_kernel->handleTempoSetting(currentTempo);
             }
         }
         return noErr;

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPCompressor.hpp
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPCompressor.hpp
@@ -1,0 +1,80 @@
+//
+//  S1DSPCompressor.hpp
+//  AudioKitSynthOne
+//
+//  Created by Matthias Frick on 11/03/2019.
+//  Copyright © 2019 AudioKit. All rights reserved.
+//
+
+#import "AudioKit/AKSoundpipeKernel.hpp"
+#import "S1Parameter.h"
+
+#ifndef S1DSPCompressor_h
+#define S1DSPCompressor_h
+using DSPParameters = std::array<float, S1Parameter::S1ParameterCount>;
+
+struct SPCompressorDeleter {
+    void operator()(sp_compressor* compInst) const {
+        sp_compressor_destroy(&compInst);
+    }
+};
+
+struct SPCompressorAllocator {
+    static auto allocate() -> sp_compressor* {
+        sp_compressor* compPtr;
+        sp_compressor_create(&compPtr);
+        return compPtr;
+    }
+};
+
+template<int RatioP, int ThresholdP, int AttP, int RelP, int MakeupP = -1>
+struct S1Compressor {
+
+    S1Compressor() = delete;
+    S1Compressor(S1Compressor&&) = delete;
+    S1Compressor(const S1Compressor&) = delete;
+
+    S1Compressor(sp_data* sp, DSPParameters* params) :
+        mSp(sp),
+        mParams(params),
+        mCompressorL(SPCompressorAllocator::allocate()),
+        mCompressorR(SPCompressorAllocator::allocate())
+    {
+        sp_compressor_init(mSp, mCompressorR.get());
+        sp_compressor_init(mSp, mCompressorL.get());
+    }
+
+    void compute(float &inL, float &inR, float &outL, float &outR) {
+        configure(mCompressorR.get());
+        configure(mCompressorL.get());
+        compute(mCompressorR.get(), inR, outR);
+        compute(mCompressorL.get(), inL, outL);
+        if (MakeupP != -1) {
+            outR *= (*mParams)[MakeupP];
+            outL *= (*mParams)[MakeupP];
+        }
+    }
+
+private:
+
+    void configure(sp_compressor *comp) {
+        *comp->atk = (*mParams)[AttP];
+        *comp->rel = (*mParams)[RelP];
+        *comp->thresh = (*mParams)[ThresholdP];
+        *comp->ratio = (*mParams)[RatioP];
+    }
+
+    void compute(sp_compressor *comp, float &in, float &out) {
+        sp_compressor_compute(mSp, comp, &in, &out);
+    }
+
+    // Parameter Reference
+    DSPParameters* mParams;
+
+    // DSP Internals
+    std::unique_ptr<sp_compressor, SPCompressorDeleter> mCompressorR;
+    std::unique_ptr<sp_compressor, SPCompressorDeleter> mCompressorL;
+    sp_data* mSp;
+};
+
+#endif /* S1DSPCompressor_h */

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+destroy.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+destroy.mm
@@ -34,12 +34,6 @@ void S1DSPKernel::destroy() {
     sp_buthp_destroy(&butterworthHipassR);
     sp_crossfade_destroy(&revCrossfadeL);
     sp_crossfade_destroy(&revCrossfadeR);
-    sp_compressor_destroy(&compressorMasterL);
-    sp_compressor_destroy(&compressorMasterR);
-    sp_compressor_destroy(&compressorReverbInputL);
-    sp_compressor_destroy(&compressorReverbInputR);
-    sp_compressor_destroy(&compressorReverbWetL);
-    sp_compressor_destroy(&compressorReverbWetR);
 }
 
 

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+process.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+process.mm
@@ -20,30 +20,7 @@ void S1DSPKernel::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffer
     float* outR = (float*)outBufferListPtr->mBuffers[1].mData + bufferOffset;
 
     // currently UI is visible in DEV panel only so can't be portamento
-    *compressorMasterL->ratio = parameters[compressorMasterRatio];
-    *compressorMasterR->ratio = parameters[compressorMasterRatio];
-    *compressorReverbInputL->ratio = parameters[compressorReverbInputRatio];
-    *compressorReverbInputR->ratio = parameters[compressorReverbInputRatio];
-    *compressorReverbWetL->ratio = parameters[compressorReverbWetRatio];
-    *compressorReverbWetR->ratio = parameters[compressorReverbWetRatio];
-    *compressorMasterL->thresh = parameters[compressorMasterThreshold];
-    *compressorMasterR->thresh = parameters[compressorMasterThreshold];
-    *compressorReverbInputL->thresh = parameters[compressorReverbInputThreshold];
-    *compressorReverbInputR->thresh = parameters[compressorReverbInputThreshold];
-    *compressorReverbWetL->thresh = parameters[compressorReverbWetThreshold];
-    *compressorReverbWetR->thresh = parameters[compressorReverbWetThreshold];
-    *compressorMasterL->atk = parameters[compressorMasterAttack];
-    *compressorMasterR->atk = parameters[compressorMasterAttack];
-    *compressorReverbInputL->atk = parameters[compressorReverbInputAttack];
-    *compressorReverbInputR->atk = parameters[compressorReverbInputAttack];
-    *compressorReverbWetL->atk = parameters[compressorReverbWetAttack];
-    *compressorReverbWetR->atk = parameters[compressorReverbWetAttack];
-    *compressorMasterL->rel = parameters[compressorMasterRelease];
-    *compressorMasterR->rel = parameters[compressorMasterRelease];
-    *compressorReverbInputL->rel = parameters[compressorReverbInputRelease];
-    *compressorReverbInputR->rel = parameters[compressorReverbInputRelease];
-    *compressorReverbWetL->rel = parameters[compressorReverbWetRelease];
-    *compressorReverbWetR->rel = parameters[compressorReverbWetRelease];
+
 
     /// transition playing notes from release to off
     if (parameters[isMono] > 0.f) {
@@ -276,10 +253,7 @@ void S1DSPKernel::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffer
         butOutR *= 2.f;
         float butCompressOutL = 0.f;
         float butCompressOutR = 0.f;
-        sp_compressor_compute(sp, compressorReverbInputL, &butOutL, &butCompressOutL);
-        sp_compressor_compute(sp, compressorReverbInputR, &butOutR, &butCompressOutR);
-        butCompressOutL *= parameters[compressorReverbInputMakeupGain];
-        butCompressOutR *= parameters[compressorReverbInputMakeupGain];
+        mCompReverbIn.compute(butOutL, butOutR, butCompressOutL, butCompressOutR);
 
         // REVERB
         float reverbWetL = 0.f;
@@ -291,10 +265,7 @@ void S1DSPKernel::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffer
         // compressor for wet reverb; like X2, FM
         float wetReverbLimiterL = reverbWetL;
         float wetReverbLimiterR = reverbWetR;
-        sp_compressor_compute(sp, compressorReverbWetL, &reverbWetL, &wetReverbLimiterL);
-        sp_compressor_compute(sp, compressorReverbWetR, &reverbWetR, &wetReverbLimiterR);
-        wetReverbLimiterL *= parameters[compressorReverbWetMakeupGain];
-        wetReverbLimiterR *= parameters[compressorReverbWetMakeupGain];
+        mCompReverbWet.compute(reverbWetL, reverbWetR, wetReverbLimiterL, wetReverbLimiterR);
 
         // crossfade wet reverb with wet+dry delay
         float reverbCrossfadeOutL = 0.f;
@@ -319,12 +290,7 @@ void S1DSPKernel::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffer
         float compressorOutR = reverbCrossfadeOutR;
 
         // MASTER COMPRESSOR TOGGLE: 0 = no compressor, 1 = compressor
-        sp_compressor_compute(sp, compressorMasterL, &reverbCrossfadeOutL, &compressorOutL);
-        sp_compressor_compute(sp, compressorMasterR, &reverbCrossfadeOutR, &compressorOutR);
-
-        // Makeup Gain on Master Compressor
-        compressorOutL *= parameters[compressorMasterMakeupGain];
-        compressorOutR *= parameters[compressorMasterMakeupGain];
+        mCompMaster.compute(reverbCrossfadeOutL, reverbCrossfadeOutR, compressorOutL, compressorOutR);
 
         // WIDEN: constant delay with no filtering, so functionally equivalent to being inside master
         float widenOutR = 0.f;

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
@@ -19,6 +19,7 @@
 #import "S1Parameter.h"
 #import "S1Rate.hpp"
 #import "../Sequencer/S1Sequencer.hpp"
+#import "S1DSPCompressor.hpp"
 
 @class AEArray;
 @class AEMessageQueue;
@@ -309,8 +310,12 @@ private:
     sp_buthp *butterworthHipassR;
     sp_crossfade *revCrossfadeL;
     sp_crossfade *revCrossfadeR;
-    sp_compressor *compressorMasterL;
-    sp_compressor *compressorMasterR;
+    S1Compressor<compressorMasterRatio, compressorMasterThreshold,
+        compressorMasterAttack, compressorMasterRelease, compressorMasterMakeupGain> mCompMaster;
+    S1Compressor<compressorReverbInputRatio, compressorReverbInputThreshold,
+        compressorReverbInputAttack, compressorReverbInputRelease, compressorReverbInputMakeupGain> mCompReverbIn;
+    S1Compressor<compressorReverbWetRatio, compressorReverbWetThreshold,
+        compressorReverbWetAttack, compressorReverbWetRelease, compressorReverbWetMakeupGain> mCompReverbWet;
     sp_compressor *compressorReverbInputL;
     sp_compressor *compressorReverbInputR;
     sp_compressor *compressorReverbWetL;

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
@@ -44,8 +44,13 @@ class S1DSPKernel : public AKSoundpipeKernel, public AKOutputBuffered {
 
 public:
     
-    S1DSPKernel();
-    
+    S1DSPKernel(int _channels, double _sampleRate);
+
+    // Dont allow default construction, copying or moving of Kernel.
+    S1DSPKernel() = delete;
+    S1DSPKernel(S1DSPKernel&&) = delete;
+    S1DSPKernel(const S1DSPKernel&) = delete;
+
     ~S1DSPKernel();
 
     // public accessor for protected sp

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.mm
@@ -20,6 +20,9 @@ S1DSPKernel::S1DSPKernel(int _channels, double _sampleRate) :
               std::bind(std::mem_fn<void(int)>(&S1DSPKernel::turnOffKey), this, _1),
               std::bind(std::bind(&S1DSPKernel::beatCounterDidChange, this))),
     AKSoundpipeKernel(_channels, _sampleRate),
+    mCompMaster(sp, &parameters),
+    mCompReverbWet(sp, &parameters),
+    mCompReverbIn(sp, &parameters)
 {
     init(_channels, _sampleRate);
 }
@@ -70,18 +73,7 @@ void S1DSPKernel::init(int _channels, double _sampleRate) {
     sp_crossfade_create(&revCrossfadeR);
     sp_crossfade_init(sp, revCrossfadeL);
     sp_crossfade_init(sp, revCrossfadeR);
-    sp_compressor_create(&compressorMasterL);
-    sp_compressor_init(sp, compressorMasterL);
-    sp_compressor_create(&compressorMasterR);
-    sp_compressor_init(sp, compressorMasterR);
-    sp_compressor_create(&compressorReverbInputL);
-    sp_compressor_init(sp, compressorReverbInputL);
-    sp_compressor_create(&compressorReverbInputR);
-    sp_compressor_init(sp, compressorReverbInputR);
-    sp_compressor_create(&compressorReverbWetL);
-    sp_compressor_init(sp, compressorReverbWetL);
-    sp_compressor_create(&compressorReverbWetR);
-    sp_compressor_init(sp, compressorReverbWetR);
+
     sp_delay_create(&widenDelay);
     sp_delay_init(sp, widenDelay, 0.05f);
     widenDelay->feedback = 0.f;
@@ -137,31 +129,6 @@ void S1DSPKernel::restoreValues(std::optional<DSPParameters> params) {
     *phaser0->feedback_gain = 0;
     *phaser0->invert = 0;
     *phaser0->lfobpm = 30;
-
-    *compressorMasterL->ratio = getSynthParameter(compressorMasterRatio);
-    *compressorMasterR->ratio = getSynthParameter(compressorMasterRatio);
-    *compressorReverbInputL->ratio = getSynthParameter(compressorReverbInputRatio);
-    *compressorReverbInputR->ratio = getSynthParameter(compressorReverbInputRatio);
-    *compressorReverbWetL->ratio = getSynthParameter(compressorReverbWetRatio);
-    *compressorReverbWetR->ratio = getSynthParameter(compressorReverbWetRatio);
-    *compressorMasterL->thresh = getSynthParameter(compressorMasterThreshold);
-    *compressorMasterR->thresh = getSynthParameter(compressorMasterThreshold);
-    *compressorReverbInputL->thresh = getSynthParameter(compressorReverbInputThreshold);
-    *compressorReverbInputR->thresh = getSynthParameter(compressorReverbInputThreshold);
-    *compressorReverbWetL->thresh = getSynthParameter(compressorReverbWetThreshold);
-    *compressorReverbWetR->thresh = getSynthParameter(compressorReverbWetThreshold);
-    *compressorMasterL->atk = getSynthParameter(compressorMasterAttack);
-    *compressorMasterR->atk = getSynthParameter(compressorMasterAttack);
-    *compressorReverbInputL->atk = getSynthParameter(compressorReverbInputAttack);
-    *compressorReverbInputR->atk = getSynthParameter(compressorReverbInputAttack);
-    *compressorReverbWetL->atk = getSynthParameter(compressorReverbWetAttack);
-    *compressorReverbWetR->atk = getSynthParameter(compressorReverbWetAttack);
-    *compressorMasterL->rel = getSynthParameter(compressorMasterRelease);
-    *compressorMasterR->rel = getSynthParameter(compressorMasterRelease);
-    *compressorReverbInputL->rel = getSynthParameter(compressorReverbInputRelease);
-    *compressorReverbInputR->rel = getSynthParameter(compressorReverbInputRelease);
-    *compressorReverbWetL->rel = getSynthParameter(compressorReverbWetRelease);
-    *compressorReverbWetR->rel = getSynthParameter(compressorReverbWetRelease);
 
     loPassInputDelayL->freq = getSynthParameter(cutoff);
     loPassInputDelayL->res = getSynthParameter(delayInputResonance);

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.mm
@@ -15,16 +15,20 @@
 
 using namespace std::placeholders;
 
-S1DSPKernel::S1DSPKernel() :
+S1DSPKernel::S1DSPKernel(int _channels, double _sampleRate) :
     sequencer(std::bind(std::mem_fn<void(int, int)>(&S1DSPKernel::turnOnKey), this, _1, _2),
               std::bind(std::mem_fn<void(int)>(&S1DSPKernel::turnOffKey), this, _1),
-              std::bind(std::bind(&S1DSPKernel::beatCounterDidChange, this))) {
+              std::bind(std::bind(&S1DSPKernel::beatCounterDidChange, this))),
+    AKSoundpipeKernel(_channels, _sampleRate),
+{
+    init(_channels, _sampleRate);
 }
 
 S1DSPKernel::~S1DSPKernel() = default;
 
 void S1DSPKernel::init(int _channels, double _sampleRate) {
-    AKSoundpipeKernel::init(_channels, _sampleRate);
+    sp->sr = _sampleRate;
+    sp->nchan = _channels;
     sp_ftbl_create(sp, &sine, S1_FTABLE_SIZE);
     sp_gen_sine(sp, sine);
     sp_phasor_create(&lfo1Phasor);

--- a/AudioKitSynthOne/MIDI/MIDISettingsViewController.swift
+++ b/AudioKitSynthOne/MIDI/MIDISettingsViewController.swift
@@ -258,9 +258,9 @@ extension MIDISettingsViewController: UITableViewDelegate {
 
         // Open / Close MIDI Input
         if midiInput.isOpen {
-            AudioKit.midi.openInput(midiInput.name)
+            AudioKit.midi.openInput(name: midiInput.name)
         } else {
-            AudioKit.midi.closeInput(midiInput.name)
+            AudioKit.midi.closeInput(name: midiInput.name)
         }
 
         delegate?.didChangeMIDISources(midiSources)

--- a/AudioKitSynthOne/MIDI/Manager+MIDIListener.swift
+++ b/AudioKitSynthOne/MIDI/Manager+MIDIListener.swift
@@ -165,7 +165,7 @@ extension Manager: AKMIDIListener {
 
             let newMIDI = MIDIInput(name: inputName, isOpen: true)
             midiInputs.append(newMIDI)
-            AudioKit.midi.openInput(inputName)
+            AudioKit.midi.openInput(name: inputName)
         }
     }
 

--- a/AudioKitSynthOne/Manager/Manager.swift
+++ b/AudioKitSynthOne/Manager/Manager.swift
@@ -174,7 +174,7 @@ public class Manager: UpdatableViewController {
         DispatchQueue.global(qos: .userInteractive).async {
             AudioKit.midi.createVirtualInputPort(95_433, name: "AudioKit Synth One")
             AudioKit.midi.openInput()
-            AudioKit.midi.openOutput("AudioKit Synth One")
+            AudioKit.midi.openOutput(name: "AudioKit Synth One")
         }
         AudioKit.midi.addListener(self)
 

--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,7 @@ use_frameworks!
 source 'https://github.com/CocoaPods/Specs.git'
 
 def available_pods
-    pod 'AudioKit', '>= 4.5'
+    pod 'AudioKit', '>= 4.6'
     pod 'Disk', '~> 0.3.2'
     pod 'Audiobus'
     pod 'ChimpKit'
@@ -19,7 +19,7 @@ end
 
 target 'OneSignalNotificationServiceExtension' do
     pod 'OneSignal', '>= 2.6.2', '< 3.0'
-    pod 'AudioKit', '>= 4.5'
+    pod 'AudioKit', '>= 4.6'
 end
 
 


### PR DESCRIPTION
Hey everyone,

I took a stab at making the Kernel more RAII friendly.
I also extracted the C-Calls to the Compressor into a separate class to handle all RAII (and also inject the DSPParameters at Compile-Time).

Please take a look at 
https://github.com/AudioKit/AudioKitSynthOne/commit/b29f6690f174922d7d9194e63a01cce4675a30e1 specifically.

This PR is also dependent on https://github.com/AudioKit/AudioKit/pull/1704 in the AK Repo.

I didn't notice any increase in CPU Performance with this.

ping @aure @marcussatellite @analogcode 