### PR TITLE
Use Staging Repo for AK 4.7.1b1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,11 +2,11 @@ platform :ios, '10.0'
 use_frameworks!
 
 # This enables the cutting-edge staging builds of AudioKit, comment this line to stick to stable releases
-#source 'https://github.com/AudioKit/Specs.git'
+source 'https://github.com/AudioKit/Specs.git'
 source 'https://github.com/CocoaPods/Specs.git'
 
 def available_pods
-    pod 'AudioKit', '>= 4.7'
+    pod 'AudioKit', '>= 4.7.1b1'
     pod 'Disk', '~> 0.3.2'
     pod 'Audiobus'
     pod 'ChimpKit'
@@ -19,7 +19,7 @@ end
 
 target 'OneSignalNotificationServiceExtension' do
     pod 'OneSignal', '>= 2.6.2', '< 3.0'
-    pod 'AudioKit', '>= 4.7'
+    pod 'AudioKit', '>= 4.7.1b1'
 end
 
 


### PR DESCRIPTION
This should make CI go green again and bump us up to Swift 5.

We should probably switch to 4.7.1 mainline once it goes live.

Happy to close this if we just want to wait for that.

ping @analogcode @marcussatellite @aure 