### PR TITLE
Add -fno-aligned-allocation to Compile Flags

### DIFF
--- a/AudioKitSynthOne.xcodeproj/project.pbxproj
+++ b/AudioKitSynthOne.xcodeproj/project.pbxproj
@@ -2360,7 +2360,10 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/AudioKitSynthOne/Link/lib",
 				);
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-fno-aligned-allocation",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"$(ABLETON_LIB_$(ABLETON_ENABLED))",
@@ -2398,7 +2401,10 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/AudioKitSynthOne/Link/lib",
 				);
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-fno-aligned-allocation",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"$(ABLETON_LIB_$(ABLETON_ENABLED))",


### PR DESCRIPTION
Add -fno-aligned-allocation since C++17 in 10.2
enforces aligned allication which iOS <11 does not support.

ping @analogcode 