### PR TITLE
Tuning bank on launch

### DIFF
--- a/AudioKitSynthOne.xcodeproj/project.pbxproj
+++ b/AudioKitSynthOne.xcodeproj/project.pbxproj
@@ -1678,7 +1678,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AudioKitSynthOne/Pods-AudioKitSynthOne-frameworks.sh",
+				"${SRCROOT}/Pods/Target Support Files/Pods-AudioKitSynthOne/Pods-AudioKitSynthOne-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/ChimpKit/ChimpKit.framework",
 				"${BUILT_PRODUCTS_DIR}/Disk/Disk.framework",
 			);
@@ -1689,7 +1689,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AudioKitSynthOne/Pods-AudioKitSynthOne-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AudioKitSynthOne/Pods-AudioKitSynthOne-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		C4421AA920B81D0500BE9F12 /* ShellScript */ = {

--- a/AudioKitSynthOne/Base.lproj/Main.storyboard
+++ b/AudioKitSynthOne/Base.lproj/Main.storyboard
@@ -1276,14 +1276,14 @@
                                 <color key="backgroundColor" red="0.15686274510000001" green="0.15686274510000001" blue="0.15686274510000001" alpha="1" colorSpace="calibratedRGB"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tKC-fD-PQm">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="420"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="378"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Spu-aU-mjx">
-                                        <rect key="frame" x="0.0" y="0.0" width="600" height="51"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="MIDI / SETTINGS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.59999999999999998" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ksJ-GG-fPC">
-                                                <rect key="frame" x="17" y="13" width="175" height="24"/>
+                                                <rect key="frame" x="17" y="11" width="175" height="24"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
@@ -1293,7 +1293,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lW8-Xt-97c">
-                                                <rect key="frame" x="516" y="7" width="77" height="36"/>
+                                                <rect key="frame" x="516" y="5" width="77" height="36"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="DoneButton"/>
                                                 <fontDescription key="fontDescription" name="AvenirNextCondensed-DemiBold" family="Avenir Next Condensed" pointSize="17"/>
@@ -1308,7 +1308,7 @@
                                         <color key="backgroundColor" red="0.094117647060000004" green="0.094117647060000004" blue="0.094117647060000004" alpha="1" colorSpace="calibratedRGB"/>
                                     </view>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JmX-eX-97E">
-                                        <rect key="frame" x="302" y="50" width="298" height="364"/>
+                                        <rect key="frame" x="302" y="44" width="298" height="364"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Buffer Size:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dbD-NB-qaM">
@@ -1359,7 +1359,7 @@
                                         <color key="backgroundColor" red="0.14509803921568626" green="0.14509803921568626" blue="0.14509803921568626" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="MIDI Input Channel: Omni" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pI1-4q-bLo">
-                                        <rect key="frame" x="19" y="66" width="268" height="24"/>
+                                        <rect key="frame" x="19" y="53" width="268" height="24"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <accessibility key="accessibilityConfiguration">
                                             <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
@@ -1369,7 +1369,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j6L-yF-WkZ" customClass="ChannelStepper" customModule="AudioKitSynthOne">
-                                        <rect key="frame" x="97" y="92" width="108" height="35"/>
+                                        <rect key="frame" x="97" y="79" width="108" height="35"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <accessibility key="accessibilityConfiguration" identifier="MIDIInputStepper" label="MIDI Input Channel">
@@ -1378,7 +1378,7 @@
                                         </accessibility>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="MIDI Learn Knobs:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VLa-3E-3Kt">
-                                        <rect key="frame" x="19" y="142" width="263" height="24"/>
+                                        <rect key="frame" x="19" y="122" width="263" height="24"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <accessibility key="accessibilityConfiguration">
                                             <accessibilityTraits key="traits" notEnabled="YES"/>
@@ -1389,7 +1389,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MQe-Qa-FAj" customClass="SynthButton" customModule="AudioKitSynthOne">
-                                        <rect key="frame" x="36" y="169" width="235" height="34"/>
+                                        <rect key="frame" x="36" y="147" width="235" height="34"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" red="0.26693210010000001" green="0.26649737359999998" blue="0.28525885940000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <accessibility key="accessibilityConfiguration" identifier="ResetMIDILearnButton" label="Reset MIDI Learn Knobs"/>
@@ -1403,7 +1403,7 @@
                                         </state>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Velocity Sensitive MIDI: " textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nzb-kU-xl1">
-                                        <rect key="frame" x="19" y="219" width="180" height="24"/>
+                                        <rect key="frame" x="17" y="202" width="180" height="24"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <accessibility key="accessibilityConfiguration">
                                             <accessibilityTraits key="traits" notEnabled="YES"/>
@@ -1422,7 +1422,7 @@
                                         </attributedString>
                                     </label>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ciI-3c-py9" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
-                                        <rect key="frame" x="204" y="214" width="49" height="36"/>
+                                        <rect key="frame" x="206" y="197" width="49" height="36"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <accessibility key="accessibilityConfiguration" identifier="VelocitySensitiveToggle" label="Velocity Sensitive MIDI">
@@ -1431,20 +1431,11 @@
                                         </accessibility>
                                     </view>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5pp-Bd-T3Z">
-                                        <rect key="frame" x="2" y="252" width="300" height="41"/>
+                                        <rect key="frame" x="0.0" y="232" width="302" height="35"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2qN-E6-I52" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
-                                                <rect key="frame" x="204" y="5" width="49" height="36"/>
-                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <accessibility key="accessibilityConfiguration" hint="App does not sleep." identifier="AlwaysOnToggle" label="App Always On">
-                                                    <accessibilityTraits key="traits" button="YES"/>
-                                                    <bool key="isElement" value="YES"/>
-                                                </accessibility>
-                                            </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="App Always on / Don't sleep:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UeB-Ec-gRc">
-                                                <rect key="frame" x="14" y="8" width="180" height="24"/>
+                                                <rect key="frame" x="15" y="6" width="181" height="24"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <accessibilityTraits key="traits" notEnabled="YES"/>
@@ -1462,11 +1453,20 @@
                                                     </fragment>
                                                 </attributedString>
                                             </label>
+                                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2qN-E6-I52" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
+                                                <rect key="frame" x="204" y="3" width="49" height="36"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <accessibility key="accessibilityConfiguration" hint="App does not sleep." identifier="AlwaysOnToggle" label="App Always On">
+                                                    <accessibilityTraits key="traits" button="YES"/>
+                                                    <bool key="isElement" value="YES"/>
+                                                </accessibility>
+                                            </view>
                                         </subviews>
                                         <color key="backgroundColor" red="0.15686274509803921" green="0.15686274509803921" blue="0.15686274509803921" alpha="1" colorSpace="calibratedRGB"/>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Background Audio Always On:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sxO-Cg-8JK">
-                                        <rect key="frame" x="19" y="302" width="180" height="24"/>
+                                        <rect key="frame" x="16" y="275" width="180" height="24"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <accessibility key="accessibilityConfiguration">
                                             <accessibilityTraits key="traits" notEnabled="YES"/>
@@ -1476,21 +1476,12 @@
                                         <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qK0-RZ-jCN" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
-                                        <rect key="frame" x="204" y="296" width="49" height="36"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <accessibility key="accessibilityConfiguration" hint="Sets if apps plays in the background." identifier="BackgroundAudioToggle" label="Background Audio">
-                                            <accessibilityTraits key="traits" button="YES"/>
-                                            <bool key="isElement" value="YES"/>
-                                        </accessibility>
-                                    </view>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a3K-SY-hHt">
-                                        <rect key="frame" x="1" y="333" width="300" height="41"/>
+                                        <rect key="frame" x="0.0" y="305" width="302" height="35"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Save + Load Tuning With Preset:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MlE-O3-Ji5">
-                                                <rect key="frame" x="10" y="9" width="189" height="24"/>
+                                                <rect key="frame" x="8" y="6" width="189" height="24"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <accessibilityTraits key="traits" notEnabled="YES"/>
@@ -1501,7 +1492,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QvN-tN-KKa" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
-                                                <rect key="frame" x="204" y="5" width="49" height="36"/>
+                                                <rect key="frame" x="206" y="3" width="49" height="36"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <accessibility key="accessibilityConfiguration" hint="Saves Tuning Panel with Preset" identifier="SaveTuningToggle" label="Save Tuning">
@@ -1513,7 +1504,7 @@
                                         <color key="backgroundColor" red="0.15686274510000001" green="0.15686274510000001" blue="0.15686274510000001" alpha="1" colorSpace="calibratedRGB"/>
                                     </view>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cMA-Db-Y5l" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
-                                        <rect key="frame" x="204" y="379" width="49" height="36"/>
+                                        <rect key="frame" x="207" y="345" width="49" height="36"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <accessibility key="accessibilityConfiguration" hint="Sets if apps plays in the background." identifier="BackgroundAudioToggle" label="Background Audio">
@@ -1522,7 +1513,7 @@
                                         </accessibility>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Launch With Last Tuning:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fAs-Es-4DF">
-                                        <rect key="frame" x="20" y="385" width="180" height="24"/>
+                                        <rect key="frame" x="17" y="348" width="180" height="24"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <accessibility key="accessibilityConfiguration">
                                             <accessibilityTraits key="traits" notEnabled="YES"/>
@@ -1532,10 +1523,19 @@
                                         <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qK0-RZ-jCN" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
+                                        <rect key="frame" x="206" y="272" width="49" height="36"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <accessibility key="accessibilityConfiguration" hint="Sets if apps plays in the background." identifier="BackgroundAudioToggle" label="Background Audio">
+                                            <accessibilityTraits key="traits" button="YES"/>
+                                            <bool key="isElement" value="YES"/>
+                                        </accessibility>
+                                    </view>
                                 </subviews>
                                 <color key="backgroundColor" red="0.13333333333333333" green="0.13333333333333333" blue="0.13333333333333333" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="420" id="pcF-wM-383"/>
+                                    <constraint firstAttribute="height" constant="378" id="pcF-wM-383"/>
                                     <constraint firstAttribute="width" constant="600" id="v1M-fU-Z86"/>
                                 </constraints>
                             </view>

--- a/AudioKitSynthOne/Base.lproj/Main.storyboard
+++ b/AudioKitSynthOne/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="ipad9_7" orientation="landscape">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -1276,37 +1276,8 @@
                                 <color key="backgroundColor" red="0.15686274510000001" green="0.15686274510000001" blue="0.15686274510000001" alpha="1" colorSpace="calibratedRGB"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tKC-fD-PQm">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="380"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="420"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5pp-Bd-T3Z">
-                                        <rect key="frame" x="3" y="252" width="300" height="41"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" red="0.15686274509803921" green="0.15686274509803921" blue="0.15686274509803921" alpha="1" colorSpace="calibratedRGB"/>
-                                    </view>
-                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JmX-eX-97E">
-                                        <rect key="frame" x="302" y="50" width="298" height="330"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="On older iPads, close all other apps. Or, restart your iPad with only Synth One running." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sEd-Th-Wg6">
-                                                <rect key="frame" x="15" y="129" width="268" height="60"/>
-                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                <accessibility key="accessibilityConfiguration">
-                                                    <accessibilityTraits key="traits" notEnabled="YES"/>
-                                                    <bool key="isElement" value="NO"/>
-                                                </accessibility>
-                                                <fontDescription key="fontDescription" name="AvenirNextCondensed-Medium" family="Avenir Next Condensed" pointSize="16"/>
-                                                <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" red="0.14509803921568626" green="0.14509803921568626" blue="0.14509803921568626" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                    </view>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Buffer Size:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dbD-NB-qaM">
-                                        <rect key="frame" x="385" y="82" width="140" height="22"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <fontDescription key="fontDescription" name="AvenirNextCondensed-DemiBold" family="Avenir Next Condensed" pointSize="16"/>
-                                        <color key="textColor" red="0.70588235290000001" green="0.70588235290000001" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                    </label>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Spu-aU-mjx">
                                         <rect key="frame" x="0.0" y="0.0" width="600" height="51"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -1336,45 +1307,73 @@
                                         </subviews>
                                         <color key="backgroundColor" red="0.094117647060000004" green="0.094117647060000004" blue="0.094117647060000004" alpha="1" colorSpace="calibratedRGB"/>
                                     </view>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MQe-Qa-FAj" customClass="SynthButton" customModule="AudioKitSynthOne">
-                                        <rect key="frame" x="36" y="169" width="235" height="34"/>
+                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JmX-eX-97E">
+                                        <rect key="frame" x="302" y="50" width="298" height="364"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" red="0.26693210010000001" green="0.26649737359999998" blue="0.28525885940000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="ResetMIDILearnButton" label="Reset MIDI Learn Knobs"/>
-                                        <fontDescription key="fontDescription" name="AvenirNextCondensed-Regular" family="Avenir Next Condensed" pointSize="16"/>
-                                        <color key="tintColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                        <state key="normal" title="Reset MIDI Learn Knobs">
-                                            <color key="titleColor" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                        </state>
-                                        <state key="selected">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        </state>
-                                    </button>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="App Always on / Don't sleep:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UeB-Ec-gRc">
-                                        <rect key="frame" x="19" y="260" width="180" height="24"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Buffer Size:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dbD-NB-qaM">
+                                                <rect key="frame" x="79" y="31" width="140" height="22"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" name="AvenirNextCondensed-DemiBold" family="Avenir Next Condensed" pointSize="16"/>
+                                                <color key="textColor" red="0.70588235290000001" green="0.70588235290000001" blue="0.72549019609999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            </label>
+                                            <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="aHe-gl-BT6">
+                                                <rect key="frame" x="25" y="61" width="249" height="29"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <segments>
+                                                    <segment title="32"/>
+                                                    <segment title="64"/>
+                                                    <segment title="128"/>
+                                                    <segment title="256"/>
+                                                    <segment title="512"/>
+                                                    <segment title="1024"/>
+                                                </segments>
+                                                <color key="tintColor" red="0.57254901960000004" green="0.57254901960000004" blue="0.59215686270000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <connections>
+                                                    <action selector="bufferSizeChanged:" destination="wQW-DI-keW" eventType="valueChanged" id="tLV-eM-hvR"/>
+                                                </connections>
+                                            </segmentedControl>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Raise the buffer if you're hearing crackles." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fbu-9N-2fS">
+                                                <rect key="frame" x="18" y="103" width="263" height="24"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <accessibilityTraits key="traits" notEnabled="YES"/>
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
+                                                <fontDescription key="fontDescription" name="AvenirNextCondensed-Medium" family="Avenir Next Condensed" pointSize="16"/>
+                                                <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="On older iPads, close all other apps. Or, restart your iPad with only Synth One running." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sEd-Th-Wg6">
+                                                <rect key="frame" x="15" y="148" width="268" height="60"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <accessibilityTraits key="traits" notEnabled="YES"/>
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
+                                                <fontDescription key="fontDescription" name="AvenirNextCondensed-Medium" family="Avenir Next Condensed" pointSize="16"/>
+                                                <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" red="0.14509803921568626" green="0.14509803921568626" blue="0.14509803921568626" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="MIDI Input Channel: Omni" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pI1-4q-bLo">
+                                        <rect key="frame" x="19" y="66" width="268" height="24"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <accessibility key="accessibilityConfiguration">
-                                            <accessibilityTraits key="traits" notEnabled="YES"/>
-                                            <bool key="isElement" value="NO"/>
+                                            <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
                                         </accessibility>
                                         <fontDescription key="fontDescription" name="AvenirNextCondensed-Medium" family="Avenir Next Condensed" pointSize="16"/>
                                         <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
-                                        <attributedString key="userComments">
-                                            <fragment content="App will not go into background mode toggle">
-                                                <attributes>
-                                                    <font key="NSFont" metaFont="smallSystem"/>
-                                                    <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                </attributes>
-                                            </fragment>
-                                        </attributedString>
                                     </label>
-                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2qN-E6-I52" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
-                                        <rect key="frame" x="207" y="257" width="49" height="36"/>
+                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j6L-yF-WkZ" customClass="ChannelStepper" customModule="AudioKitSynthOne">
+                                        <rect key="frame" x="97" y="92" width="108" height="35"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <accessibility key="accessibilityConfiguration" hint="App does not sleep." identifier="AlwaysOnToggle" label="App Always On">
-                                            <accessibilityTraits key="traits" button="YES"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="MIDIInputStepper" label="MIDI Input Channel">
+                                            <accessibilityTraits key="traits" adjustable="YES"/>
                                             <bool key="isElement" value="YES"/>
                                         </accessibility>
                                     </view>
@@ -1389,99 +1388,20 @@
                                         <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qK0-RZ-jCN" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
-                                        <rect key="frame" x="207" y="299" width="49" height="36"/>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MQe-Qa-FAj" customClass="SynthButton" customModule="AudioKitSynthOne">
+                                        <rect key="frame" x="36" y="169" width="235" height="34"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <accessibility key="accessibilityConfiguration" hint="Sets if apps plays in the background." identifier="BackgroundAudioToggle" label="Background Audio">
-                                            <accessibilityTraits key="traits" button="YES"/>
-                                            <bool key="isElement" value="YES"/>
-                                        </accessibility>
-                                    </view>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Raise the buffer if you're hearing crackles." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fbu-9N-2fS">
-                                        <rect key="frame" x="326" y="148" width="263" height="24"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <accessibility key="accessibilityConfiguration">
-                                            <accessibilityTraits key="traits" notEnabled="YES"/>
-                                            <bool key="isElement" value="NO"/>
-                                        </accessibility>
-                                        <fontDescription key="fontDescription" name="AvenirNextCondensed-Medium" family="Avenir Next Condensed" pointSize="16"/>
-                                        <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Background Audio Always On:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sxO-Cg-8JK">
-                                        <rect key="frame" x="19" y="302" width="180" height="24"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <accessibility key="accessibilityConfiguration">
-                                            <accessibilityTraits key="traits" notEnabled="YES"/>
-                                            <bool key="isElement" value="NO"/>
-                                        </accessibility>
-                                        <fontDescription key="fontDescription" name="AvenirNextCondensed-Medium" family="Avenir Next Condensed" pointSize="16"/>
-                                        <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="MIDI Input Channel: Omni" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pI1-4q-bLo">
-                                        <rect key="frame" x="19" y="66" width="268" height="24"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <accessibility key="accessibilityConfiguration">
-                                            <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
-                                        </accessibility>
-                                        <fontDescription key="fontDescription" name="AvenirNextCondensed-Medium" family="Avenir Next Condensed" pointSize="16"/>
-                                        <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="aHe-gl-BT6">
-                                        <rect key="frame" x="330" y="110" width="249" height="29"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <segments>
-                                            <segment title="32"/>
-                                            <segment title="64"/>
-                                            <segment title="128"/>
-                                            <segment title="256"/>
-                                            <segment title="512"/>
-                                            <segment title="1024"/>
-                                        </segments>
-                                        <color key="tintColor" red="0.57254901960000004" green="0.57254901960000004" blue="0.59215686270000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                        <connections>
-                                            <action selector="bufferSizeChanged:" destination="wQW-DI-keW" eventType="valueChanged" id="tLV-eM-hvR"/>
-                                        </connections>
-                                    </segmentedControl>
-                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ciI-3c-py9" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
-                                        <rect key="frame" x="207" y="214" width="49" height="36"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="VelocitySensitiveToggle" label="Velocity Sensitive MIDI">
-                                            <accessibilityTraits key="traits" button="YES"/>
-                                            <bool key="isElement" value="YES"/>
-                                        </accessibility>
-                                    </view>
-                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j6L-yF-WkZ" customClass="ChannelStepper" customModule="AudioKitSynthOne">
-                                        <rect key="frame" x="97" y="92" width="108" height="35"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="MIDIInputStepper" label="MIDI Input Channel">
-                                            <accessibilityTraits key="traits" adjustable="YES"/>
-                                            <bool key="isElement" value="YES"/>
-                                        </accessibility>
-                                    </view>
-                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a3K-SY-hHt">
-                                        <rect key="frame" x="0.0" y="333" width="300" height="47"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Save Tuning Panel w/ Presets:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MlE-O3-Ji5">
-                                                <rect key="frame" x="10" y="9" width="189" height="24"/>
-                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                <accessibility key="accessibilityConfiguration">
-                                                    <accessibilityTraits key="traits" notEnabled="YES"/>
-                                                    <bool key="isElement" value="NO"/>
-                                                </accessibility>
-                                                <fontDescription key="fontDescription" name="AvenirNextCondensed-Medium" family="Avenir Next Condensed" pointSize="16"/>
-                                                <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" red="0.15686274510000001" green="0.15686274510000001" blue="0.15686274510000001" alpha="1" colorSpace="calibratedRGB"/>
-                                    </view>
+                                        <color key="backgroundColor" red="0.26693210010000001" green="0.26649737359999998" blue="0.28525885940000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="ResetMIDILearnButton" label="Reset MIDI Learn Knobs"/>
+                                        <fontDescription key="fontDescription" name="AvenirNextCondensed-Regular" family="Avenir Next Condensed" pointSize="16"/>
+                                        <color key="tintColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        <state key="normal" title="Reset MIDI Learn Knobs">
+                                            <color key="titleColor" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        </state>
+                                        <state key="selected">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                    </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Velocity Sensitive MIDI: " textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nzb-kU-xl1">
                                         <rect key="frame" x="19" y="219" width="180" height="24"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -1501,19 +1421,121 @@
                                             </fragment>
                                         </attributedString>
                                     </label>
-                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QvN-tN-KKa" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
-                                        <rect key="frame" x="207" y="338" width="49" height="36"/>
+                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ciI-3c-py9" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
+                                        <rect key="frame" x="204" y="214" width="49" height="36"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <accessibility key="accessibilityConfiguration" hint="Saves Tuning Panel with Preset" identifier="SaveTuningToggle" label="Save Tuning">
+                                        <accessibility key="accessibilityConfiguration" identifier="VelocitySensitiveToggle" label="Velocity Sensitive MIDI">
                                             <accessibilityTraits key="traits" button="YES"/>
                                             <bool key="isElement" value="YES"/>
                                         </accessibility>
                                     </view>
+                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5pp-Bd-T3Z">
+                                        <rect key="frame" x="2" y="252" width="300" height="41"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2qN-E6-I52" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
+                                                <rect key="frame" x="204" y="5" width="49" height="36"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <accessibility key="accessibilityConfiguration" hint="App does not sleep." identifier="AlwaysOnToggle" label="App Always On">
+                                                    <accessibilityTraits key="traits" button="YES"/>
+                                                    <bool key="isElement" value="YES"/>
+                                                </accessibility>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="App Always on / Don't sleep:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UeB-Ec-gRc">
+                                                <rect key="frame" x="14" y="8" width="180" height="24"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <accessibilityTraits key="traits" notEnabled="YES"/>
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
+                                                <fontDescription key="fontDescription" name="AvenirNextCondensed-Medium" family="Avenir Next Condensed" pointSize="16"/>
+                                                <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <nil key="highlightedColor"/>
+                                                <attributedString key="userComments">
+                                                    <fragment content="App will not go into background mode toggle">
+                                                        <attributes>
+                                                            <font key="NSFont" metaFont="smallSystem"/>
+                                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                        </attributes>
+                                                    </fragment>
+                                                </attributedString>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" red="0.15686274509803921" green="0.15686274509803921" blue="0.15686274509803921" alpha="1" colorSpace="calibratedRGB"/>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Background Audio Always On:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sxO-Cg-8JK">
+                                        <rect key="frame" x="19" y="302" width="180" height="24"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <accessibility key="accessibilityConfiguration">
+                                            <accessibilityTraits key="traits" notEnabled="YES"/>
+                                            <bool key="isElement" value="NO"/>
+                                        </accessibility>
+                                        <fontDescription key="fontDescription" name="AvenirNextCondensed-Medium" family="Avenir Next Condensed" pointSize="16"/>
+                                        <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qK0-RZ-jCN" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
+                                        <rect key="frame" x="204" y="296" width="49" height="36"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <accessibility key="accessibilityConfiguration" hint="Sets if apps plays in the background." identifier="BackgroundAudioToggle" label="Background Audio">
+                                            <accessibilityTraits key="traits" button="YES"/>
+                                            <bool key="isElement" value="YES"/>
+                                        </accessibility>
+                                    </view>
+                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a3K-SY-hHt">
+                                        <rect key="frame" x="1" y="333" width="300" height="41"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Save + Load Tuning With Preset:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MlE-O3-Ji5">
+                                                <rect key="frame" x="10" y="9" width="189" height="24"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <accessibilityTraits key="traits" notEnabled="YES"/>
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
+                                                <fontDescription key="fontDescription" name="AvenirNextCondensed-Medium" family="Avenir Next Condensed" pointSize="16"/>
+                                                <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QvN-tN-KKa" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
+                                                <rect key="frame" x="204" y="5" width="49" height="36"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <accessibility key="accessibilityConfiguration" hint="Saves Tuning Panel with Preset" identifier="SaveTuningToggle" label="Save Tuning">
+                                                    <accessibilityTraits key="traits" button="YES"/>
+                                                    <bool key="isElement" value="YES"/>
+                                                </accessibility>
+                                            </view>
+                                        </subviews>
+                                        <color key="backgroundColor" red="0.15686274510000001" green="0.15686274510000001" blue="0.15686274510000001" alpha="1" colorSpace="calibratedRGB"/>
+                                    </view>
+                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cMA-Db-Y5l" customClass="ToggleSwitch" customModule="AudioKitSynthOne">
+                                        <rect key="frame" x="204" y="379" width="49" height="36"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <accessibility key="accessibilityConfiguration" hint="Sets if apps plays in the background." identifier="BackgroundAudioToggle" label="Background Audio">
+                                            <accessibilityTraits key="traits" button="YES"/>
+                                            <bool key="isElement" value="YES"/>
+                                        </accessibility>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Launch With Last Tuning:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fAs-Es-4DF">
+                                        <rect key="frame" x="20" y="385" width="180" height="24"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <accessibility key="accessibilityConfiguration">
+                                            <accessibilityTraits key="traits" notEnabled="YES"/>
+                                            <bool key="isElement" value="NO"/>
+                                        </accessibility>
+                                        <fontDescription key="fontDescription" name="AvenirNextCondensed-Medium" family="Avenir Next Condensed" pointSize="16"/>
+                                        <color key="textColor" red="0.74509803919999995" green="0.74509803919999995" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" red="0.13333333333333333" green="0.13333333333333333" blue="0.13333333333333333" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="380" id="pcF-wM-383"/>
+                                    <constraint firstAttribute="height" constant="420" id="pcF-wM-383"/>
                                     <constraint firstAttribute="width" constant="600" id="v1M-fU-Z86"/>
                                 </constraints>
                             </view>
@@ -1532,6 +1554,7 @@
                         <outlet property="channelLabel" destination="pI1-4q-bLo" id="d6Z-FY-piO"/>
                         <outlet property="channelStepper" destination="j6L-yF-WkZ" id="SFr-on-CxL"/>
                         <outlet property="inputTable" destination="aoz-eh-ksY" id="9O6-yt-1ig"/>
+                        <outlet property="launchWithLastTuningToggle" destination="cMA-Db-Y5l" id="hBI-fh-5E9"/>
                         <outlet property="resetButton" destination="MQe-Qa-FAj" id="te0-AY-fj6"/>
                         <outlet property="saveTuningToggle" destination="QvN-tN-KKa" id="ldK-LI-seM"/>
                         <outlet property="sleepToggle" destination="2qN-E6-I52" id="XJj-mg-6vF"/>
@@ -1651,7 +1674,7 @@
         <image name="bluetooth" width="13.5" height="18"/>
         <image name="circuit" width="857" height="527.5"/>
         <image name="keyboard_top" width="1023" height="47"/>
-        <image name="rack-left" width="200" height="750"/>
+        <image name="rack-left" width="100" height="375"/>
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="P92-2d-IvO"/>

--- a/AudioKitSynthOne/Keyboard/KeyboardSettingsViewController.swift
+++ b/AudioKitSynthOne/Keyboard/KeyboardSettingsViewController.swift
@@ -9,22 +9,28 @@
 import UIKit
 
 protocol KeyboardPopOverDelegate: AnyObject {
+
     func didFinishSelecting(octaveRange: Int, labelMode: Int, darkMode: Bool)
 }
 
 class KeyboardSettingsViewController: UIViewController {
 
     @IBOutlet weak var octaveRangeSegment: UISegmentedControl!
+
     @IBOutlet weak var labelModeSegment: UISegmentedControl!
+
     @IBOutlet weak var keyboardModeSegment: UISegmentedControl!
 
     weak var delegate: KeyboardPopOverDelegate?
 
     var labelMode: Int = 1
+
     var octaveRange: Int = 2
+
     var darkMode: Bool = false
 
     override func viewDidLoad() {
+
         super.viewDidLoad()
 
         // set currently selected scale picks
@@ -36,6 +42,7 @@ class KeyboardSettingsViewController: UIViewController {
 
     // Set fonts for UISegmentedControls
     override func viewDidLayoutSubviews() {
+
         guard let font = UIFont(name: "Avenir Next Condensed", size: 15.0) else { return }
         let attr = [NSAttributedString.Key.font: font]
         labelModeSegment.setTitleTextAttributes(attr, for: .normal)
@@ -46,7 +53,6 @@ class KeyboardSettingsViewController: UIViewController {
     @IBAction func octaveRangeDidChange(_ sender: UISegmentedControl) {
 
         octaveRange = sender.selectedSegmentIndex + 1
-
         delegate?.didFinishSelecting(octaveRange: octaveRange, labelMode: labelMode, darkMode: darkMode)
     }
 
@@ -63,14 +69,11 @@ class KeyboardSettingsViewController: UIViewController {
         } else {
             darkMode = false
         }
-
         delegate?.didFinishSelecting(octaveRange: octaveRange, labelMode: labelMode, darkMode: darkMode)
     }
 
     @IBAction func closeButton(_ sender: UIButton) {
-       // delegate?.didFinishSelecting(root: selectedRoot, scaleType: selectedScaleType)
         dismiss(animated: true, completion: nil)
-
     }
 }
 

--- a/AudioKitSynthOne/MIDI/Manager+MIDISettingsPopOverDelegate.swift
+++ b/AudioKitSynthOne/MIDI/Manager+MIDISettingsPopOverDelegate.swift
@@ -48,7 +48,14 @@ extension Manager: MIDISettingsPopOverDelegate {
         saveAppSettingValues()
     }
 
-    public func storeTuningWithPresetDidChange(_ value: Bool) {
+    func didToggleStoreTuningWithPreset(_ value: Bool) {
         appSettings.saveTuningWithPreset = value
+        saveAppSettingValues()
     }
+
+    func didToggleLaunchWithLastTuning(_ value: Bool) {
+        appSettings.launchWithLastTuning = value
+        saveAppSettingValues()
+    }
+
 }

--- a/AudioKitSynthOne/Navigation/Manager+Navigation.swift
+++ b/AudioKitSynthOne/Navigation/Manager+Navigation.swift
@@ -8,7 +8,9 @@
 
 /// View Navigation/Embed Helper Methods
 extension Manager {
+    
     override public func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+
         if segue.identifier == "SegueToKeyboardSettings" {
             guard let popOverController = segue.destination as? KeyboardSettingsViewController else { return }
             popOverController.delegate = self
@@ -30,9 +32,9 @@ extension Manager {
             popOverController.userChannelIn = userMIDIChannel
             popOverController.midiSources = midiInputs
             popOverController.saveTuningWithPreset = appSettings.saveTuningWithPreset
+            popOverController.launchWithLastTuning = appSettings.launchWithLastTuning
             popOverController.velocitySensitive = appSettings.velocitySensitive
-
-            popOverController.preferredContentSize = CGSize(width: 600, height: 378)
+            popOverController.preferredContentSize = CGSize(width: 600, height: 420)
             if let presentation = popOverController.popoverPresentationController {
                 presentation.backgroundColor = #colorLiteral(red: 0.1568627451, green: 0.1568627451, blue: 0.1568627451, alpha: 1)
                 presentation.sourceRect = midiButton.bounds
@@ -62,6 +64,7 @@ extension Manager {
     }
 
     func add(asChildViewController viewController: UIViewController, isTopContainer: Bool = true) {
+
         // Add Child View Controller
         addChild(viewController)
 

--- a/AudioKitSynthOne/Navigation/Manager+Navigation.swift
+++ b/AudioKitSynthOne/Navigation/Manager+Navigation.swift
@@ -34,7 +34,8 @@ extension Manager {
             popOverController.saveTuningWithPreset = appSettings.saveTuningWithPreset
             popOverController.launchWithLastTuning = appSettings.launchWithLastTuning
             popOverController.velocitySensitive = appSettings.velocitySensitive
-            popOverController.preferredContentSize = CGSize(width: 600, height: 420)
+
+            popOverController.preferredContentSize = CGSize(width: 600, height: 378)
             if let presentation = popOverController.popoverPresentationController {
                 presentation.backgroundColor = #colorLiteral(red: 0.1568627451, green: 0.1568627451, blue: 0.1568627451, alpha: 1)
                 presentation.sourceRect = midiButton.bounds

--- a/AudioKitSynthOne/Settings/AppSettings.swift
+++ b/AudioKitSynthOne/Settings/AppSettings.swift
@@ -52,6 +52,10 @@ class AppSettings: Codable {
     //DO save current tuning (12et = nil) when preset is saved"
     //False means: "DO NOT load preset's tuning when preset is loaded.  DO NOT save current tuning when preset is saved"
     var saveTuningWithPreset = true
+
+    // When false will launch in 12ET; when true in the last-used tuning
+    var launchWithLastTuning = false
+
     var pushNotifications = false
     var userEmail = ""
     var launches = 0
@@ -69,7 +73,7 @@ class AppSettings: Codable {
     // Save State
     var currentBankIndex = 0
     var currentPresetIndex = 0
-    var currentTuningBankIndex = 0
+    var currentTuningBankIndex = Tunings.bundleBankIndex
 
     // MARK: - MIDI Learn Settings
 
@@ -159,6 +163,7 @@ class AppSettings: Codable {
         velocitySensitive = dictionary["velocitySensitive"] as? Bool ?? velocitySensitive
         presetsVersion = dictionary["presetsVersion"] as? Double ?? presetsVersion
         saveTuningWithPreset = dictionary["saveTuningWithPreset"] as? Bool ?? saveTuningWithPreset
+        launchWithLastTuning = dictionary["launchWithLastTuning"] as? Bool ?? launchWithLastTuning
 
         // HAQ Panel
         freezeArpRate = dictionary["freezeArpRate"] as? Bool ?? freezeArpRate

--- a/AudioKitSynthOne/Tunings/Model/TuningBank.swift
+++ b/AudioKitSynthOne/Tunings/Model/TuningBank.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 class TuningBank: Codable, CustomStringConvertible {
+    
     // conforming to Codable: don't change these property names
     var name = "Bundled"
     var isEditable = false

--- a/AudioKitSynthOne/Tunings/Model/Tunings.swift
+++ b/AudioKitSynthOne/Tunings/Model/Tunings.swift
@@ -79,6 +79,7 @@ class Tunings {
 
     ///
     func loadTunings(completionHandler: @escaping S1TuningLoadCallback) {
+        
         DispatchQueue.global(qos: .userInitiated).async {
             // CLEAR
             self.tuningBanks.removeAll()
@@ -182,7 +183,6 @@ class Tunings {
 
     /// saveTunings
     /// Save for the cases where selectedTuningIndex changes
-    /// TODO: Need to extend TuningBanks from array to dictionary with selectedBankIndex value
     private func saveTunings() {
         DispatchQueue.global(qos: .userInitiated).async {
             do {
@@ -321,11 +321,13 @@ class Tunings {
 
     // MARK: STATE
 
-    // Assumes tuning[0] is twelve et for all tuningBanks
     public func resetTuning() {
+
+        // Assumes 12ET is bundled at index 0
         selectedBankIndex = Tunings.bundleBankIndex
+        selectBank(atRow: selectedBankIndex)
         let b = tuningBank
-        b.selectedTuningIndex = 0
+        selectTuning(atRow: 0)
         let tuning = b.tunings[b.selectedTuningIndex]
         tuningName = tuning.name
         masterSet = tuning.masterSet

--- a/AudioKitSynthOne/Tunings/Model/Tunings.swift
+++ b/AudioKitSynthOne/Tunings/Model/Tunings.swift
@@ -72,7 +72,6 @@ class Tunings {
     internal let tuningFilenameV1 = "tunings_v1.json"
     internal static let hexanyTriadTuningsBankName = "Hexanies With Proportional Triads"
 
-
     // MARK: INIT
     init() {}
 
@@ -90,12 +89,15 @@ class Tunings {
 
             // LOAD PATH
             if Disk.exists(self.tuningFilenameV1, in: .documents) {
+
                 // tunings have been installed and/or upgraded
                 self.loadTuningsFromDevice()
             } else if Disk.exists(self.tuningFilenameV0, in: .documents) {
+
                 // tunings need to be upgraded
                 self.upgradeTuningsFromV0ToV1()
             } else {
+
                 // fresh install
                 self.loadTuningFactoryPresets()
             }

--- a/AudioKitSynthOne/Tunings/TuningsPanelController/TuningsPanel+TuneUpDelegate.swift
+++ b/AudioKitSynthOne/Tunings/TuningsPanelController/TuningsPanel+TuneUpDelegate.swift
@@ -11,10 +11,12 @@ import Foundation
 extension TuningsPanelController: TuneUpDelegate {
 
     var tuneUpBackButtonDefaultText: String {
+
         return tuningModel.tuneUpBackButtonDefaultText
     }
 
     func setTuneUpBackButtonLabel(text: String) {
+
         let isHidden = (text == tuningModel.tuneUpBackButtonDefaultText)
         tuneUpBackButtonButton.isHidden = isHidden
         tuneUpBackLabel.isHidden = isHidden
@@ -22,6 +24,7 @@ extension TuningsPanelController: TuneUpDelegate {
     }
 
     func setTuneUpBackButton(enabled: Bool) {
+        
         tuneUpBackButtonButton.isEnabled = enabled
     }
 

--- a/AudioKitSynthOne/Tunings/TuningsPanelController/TuningsPanel+UITableViewDataSource.swift
+++ b/AudioKitSynthOne/Tunings/TuningsPanelController/TuningsPanel+UITableViewDataSource.swift
@@ -11,11 +11,13 @@ import UIKit
 extension TuningsPanelController: UITableViewDataSource {
 
     public func numberOfSections(in tableView: UITableView) -> Int {
+
         return 1
     }
 
     @objc(tableView:heightForRowAtIndexPath:) public func tableView(_ tableView: UITableView,
                                                                     heightForRowAt indexPath: IndexPath) -> CGFloat {
+
         if tableView == tuningBankTableView {
             return 66
         } else {
@@ -24,6 +26,7 @@ extension TuningsPanelController: UITableViewDataSource {
     }
 
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+
         if tableView == tuningBankTableView {
             return tuningModel.tuningBanks.count
         } else if tableView == tuningTableView {
@@ -33,6 +36,7 @@ extension TuningsPanelController: UITableViewDataSource {
     }
 
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+
         tableView.separatorColor = #colorLiteral(red: 0.368627451, green: 0.368627451, blue: 0.3882352941, alpha: 1)
         let row = (indexPath as NSIndexPath).row
 
@@ -50,12 +54,12 @@ extension TuningsPanelController: UITableViewDataSource {
             cell = TuningCell()
         }
         cell.configureCell()
+
         if tableView == tuningBankTableView {
             cell.textLabel?.numberOfLines = 3
         } else {
             cell.textLabel?.numberOfLines = 3
         }
-
 
         let title: String
         if tableView == tuningBankTableView {
@@ -67,7 +71,6 @@ extension TuningsPanelController: UITableViewDataSource {
         } else {
             title = "error"
         }
-
         cell.textLabel?.text = title
 
         return cell

--- a/AudioKitSynthOne/Tunings/TuningsPanelController/TuningsPanel+UITableViewDelegate.swift
+++ b/AudioKitSynthOne/Tunings/TuningsPanelController/TuningsPanel+UITableViewDelegate.swift
@@ -11,6 +11,7 @@
 extension TuningsPanelController: UITableViewDelegate {
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+
         let selectedRow = (indexPath as NSIndexPath).row
         if tableView == tuningTableView {
             tuningModel.selectTuning(atRow: selectedRow)
@@ -46,12 +47,14 @@ extension TuningsPanelController: UITableViewDelegate {
 
     @objc(tableView:canFocusRowAtIndexPath:) func tableView(_ tableView: UITableView,
                                                             canFocusRowAt indexPath: IndexPath) -> Bool {
+
         // Only edit items in user bank
         return tableView === tuningTableView && tuningModel.selectedBankIndex == Tunings.userBankIndex
     }
 
     @objc(tableView:canEditRowAtIndexPath:) func tableView(_ tableView: UITableView,
                                                             canEditRowAt indexPath: IndexPath) -> Bool {
+        
         // Only edit items in user bank
         return tableView === tuningTableView && tuningModel.selectedBankIndex == Tunings.userBankIndex
     }

--- a/AudioKitSynthOne/Tunings/TuningsPanelController/TuningsPanelController.swift
+++ b/AudioKitSynthOne/Tunings/TuningsPanelController/TuningsPanelController.swift
@@ -110,7 +110,19 @@ class TuningsPanelController: PanelController {
         tuningModel.loadTunings {
 
             // callback called on main thread
-            self.tuningModel.selectBank(atRow: self.getAppSettingsTuningsBank())
+            guard let manager = Conductor.sharedInstance.viewControllers.first(
+                where: { $0 is Manager }) as? Manager else {
+                    self.tuningModel.resetTuning()
+                    return
+            }
+
+            let launchWithLastTuning = manager.appSettings.launchWithLastTuning
+            if launchWithLastTuning {
+                self.tuningModel.selectBank(atRow: self.getAppSettingsTuningsBank())
+            } else {
+                self.tuningModel.resetTuning()
+            }
+
             self.tuningBankTableView.reloadData()
             self.tuningTableView.reloadData()
             self.selectRow()

--- a/AudioKitSynthOne/Tunings/TuningsPanelController/TuningsPanelController.swift
+++ b/AudioKitSynthOne/Tunings/TuningsPanelController/TuningsPanelController.swift
@@ -11,6 +11,7 @@ import CloudKit
 import MobileCoreServices
 
 public protocol TuningsPitchWheelViewTuningDidChange {
+    
     func tuningDidChange()
 }
 
@@ -82,7 +83,6 @@ class TuningsPanelController: PanelController {
             masterTuningKnob.range = synth.getRange(.frequencyA4)
             masterTuningKnob.value = synth.getSynthParameter(.frequencyA4)
             Conductor.sharedInstance.bind(masterTuningKnob, to: .frequencyA4)
-
             resetTuningsButton.callback = { value in
                 if value == 1 {
                     self.tuningModel.resetTuning()
@@ -100,7 +100,6 @@ class TuningsPanelController: PanelController {
                 self.present(documentPicker, animated: true, completion: nil)
             }
             importButton.isHidden = true
-
         } else {
             AKLog("race condition: synth not yet created")
         }
@@ -111,9 +110,7 @@ class TuningsPanelController: PanelController {
         tuningModel.loadTunings {
 
             // callback called on main thread
-            if let bankIndex = self.getAppSettingsTuningsBank() {
-                self.tuningModel.selectBank(atRow: bankIndex)
-            }
+            self.tuningModel.selectBank(atRow: self.getAppSettingsTuningsBank())
             self.tuningBankTableView.reloadData()
             self.tuningTableView.reloadData()
             self.selectRow()
@@ -139,7 +136,6 @@ class TuningsPanelController: PanelController {
             }
         }
 
-        // tuneUpBackButton
         tuneUpBackButtonButton.callback = { value in
             self.tuningModel.tuneUpBackButton()
             self.tuneUpBackButtonButton.value = 0
@@ -152,6 +148,7 @@ class TuningsPanelController: PanelController {
     }
 
     public override func viewDidAppear(_ animated: Bool) {
+
         super.viewDidAppear(animated)
     }
 
@@ -161,10 +158,12 @@ class TuningsPanelController: PanelController {
     ///
     /// - Parameter playingNotes: An array of playing notes
     func playingNotesDidChange(_ playingNotes: PlayingNotes) {
+
         tuningsPitchWheelView.playingNotesDidChange(playingNotes)
     }
 
     @IBAction func randomPressed(_ sender: UIButton) {
+
         guard tuningModel.isInitialized else { return }
         tuningModel.randomTuning()
         selectRow()
@@ -176,6 +175,7 @@ class TuningsPanelController: PanelController {
     }
 
     internal func selectRow() {
+
         guard tuningModel.isInitialized else { return }
 
         let bankPath = IndexPath(row: tuningModel.selectedBankIndex, section: 0)
@@ -186,19 +186,26 @@ class TuningsPanelController: PanelController {
     }
 
     func updateAppSettingsTuningsBank(for index: Int) {
+
         guard let manager = Conductor.sharedInstance.viewControllers.first(
             where: { $0 is Manager }) as? Manager else { return }
         manager.appSettings.currentTuningBankIndex = index
         manager.saveAppSettingValues()
     }
 
-    func getAppSettingsTuningsBank() -> Int? {
+    func getAppSettingsTuningsBank() -> Int {
+
         guard let manager = Conductor.sharedInstance.viewControllers.first(
-            where: { $0 is Manager }) as? Manager else { return nil}
-        return manager.appSettings.currentTuningBankIndex
+            where: { $0 is Manager }) as? Manager else {
+                return Tunings.bundleBankIndex
+        }
+        let launchWithLastTuning = manager.appSettings.launchWithLastTuning
+        let bankIndex = launchWithLastTuning ? manager.appSettings.currentTuningBankIndex : Tunings.bundleBankIndex
+        return bankIndex
     }
 
     public func setTuning(name: String?, masterArray master: [Double]?) {
+
         guard tuningModel.isInitialized else { return }
         let reload = tuningModel.setTuning(name: name, masterArray: master)
         if reload {
@@ -208,23 +215,27 @@ class TuningsPanelController: PanelController {
     }
 
     public func setDefaultTuning() {
+
         guard tuningModel.isInitialized else { return }
         tuningModel.resetTuning()
         selectRow()
     }
 
     public func getTuning() -> (String, [Double]) {
+
         guard tuningModel.isInitialized else { return ("", [1]) }
         return tuningModel.getTuning()
     }
 
     /// redirect to redirectURL provided by last TuneUp ( "back button" )
     func tuneUpBackButton() {
+
         tuningModel.tuneUpBackButton()
     }
 
     /// openURL
     public func openUrl(url: URL) -> Bool {
+
         let retVal = tuningModel.openUrl(url: url)
         if retVal {
             selectRow()
@@ -242,6 +253,7 @@ class TuningsPanelController: PanelController {
 }
 
 extension TuningsPanelController: TuneUpPopUpDelegate {
+
     func wilsonicPressed() {
         launchWilsonic()
     }


### PR DESCRIPTION
This PR makes S1 always launches with 12ET, unless the user opts into "launch with last tuning", which is a new setting on the settings popover.