### PR TITLE
Treat Velocity 0 as Note Off

### DIFF
--- a/AudioKitSynthOne/MIDI/Manager+MIDIListener.swift
+++ b/AudioKitSynthOne/MIDI/Manager+MIDIListener.swift
@@ -14,6 +14,11 @@ extension Manager: AKMIDIListener {
     public func receivedMIDINoteOn(noteNumber: MIDINoteNumber, velocity: MIDIVelocity, channel: MIDIChannel) {
         guard channel == midiChannelIn || omniMode else { return }
         var newVelocity = velocity
+        if (velocity == 0)
+        {
+          receivedMIDINoteOff(noteNumber: noteNumber, velocity: velocity, channel: channel)
+          return
+        }
         if !appSettings.velocitySensitive { newVelocity = 127 }
         if !Thread.isMainThread {
             DispatchQueue.main.async {


### PR DESCRIPTION
We have gotten a few reports where third parties are
implementing MIDI wrong, using Velocity of 0 for
Note Off.

Therefore this commit checks for velocity and re-routes
the incoming MIDI message to the Note Off handler.

Examples:
- Using Synth One in AUM through the IAA Port.
- Using Synth One with IK Multimedia iRig Keys I/O 49*

*See another Screenshot [1] here: http://i.imgur.com/Sui8JxF.png

[1] https://cgi.ikmultimedia.com/ikforum/viewtopic.php?f=12&t=12920 

Add to Release Notes:
- Improved playing external MIDI from devices that deviate from the MIDI standard.