### PR TITLE
Add Support for Crash Log Collection

### DIFF
--- a/AudioKitSynthOne/AppDelegate.swift
+++ b/AudioKitSynthOne/AppDelegate.swift
@@ -8,6 +8,9 @@
 
 import UIKit
 import OneSignal
+import AppCenter
+import AppCenterAnalytics
+import AppCenterCrashes
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -35,7 +38,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                         settings: onesignalInitSettings)
 
         OneSignal.inFocusDisplayType = OSNotificationDisplayType.notification
-        
+
+        // Setup AppCenter for Crash Log Collection
+        if (Private.AppCenterAPIKey != "***REMOVED***") {
+            MSAppCenter.start(Private.AppCenterAPIKey, withServices:[
+                MSAnalytics.self,
+                MSCrashes.self
+                ])
+        }
+
         // Determine iPhone or iPad
         let mainStoryboard = UIStoryboard(name: "Main", bundle: Bundle.main)
         if conductor.device == .pad {

--- a/AudioKitSynthOne/Private.swift
+++ b/AudioKitSynthOne/Private.swift
@@ -25,4 +25,7 @@ class Private {
 
     // App ID for OneSignal
     public static let OneSignalAppID = "***REMOVED***"
+
+    // API Key for AppCenter
+    public static let AppCenterAPIKey = "***REMOVED***"
 }

--- a/Podfile
+++ b/Podfile
@@ -7,6 +7,7 @@ source 'https://github.com/AudioKit/Specs.git'
 source 'https://github.com/CocoaPods/Specs.git'
 
 def available_pods
+    pod 'AppCenter'
     pod 'AudioKit', '= 4.7.2.b1'
     pod 'Disk', '~> 0.3.2'
     pod 'Audiobus'


### PR DESCRIPTION
This PR adds support to automatically and anonymously collect Crash Log and basic statistics to MS App Center.
In the long-run this will help us identify crashes that we are unable to reproduce locally and therefore improve the stability of Synth One.

API Keys are removed from public repo as with other services we use.

I'll hand over instructions to @analogcode as he currently needs to upload the symbols to MS App Center for us to see where crashes are happening.