### PR TITLE
Remove additional playingNotesDidChange calls

### DIFF
--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+toggleKeys.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+toggleKeys.mm
@@ -85,7 +85,6 @@ void S1DSPKernel::turnOnKey(int noteNumber, int velocity, float frequency) {
     }
 
     heldNotesDidChange();
-    playingNotesDidChange();
 }
 
 // turnOffKey is called by render thread in "process", so access note via AEArray
@@ -166,5 +165,4 @@ void S1DSPKernel::turnOffKey(int noteNumber) {
     }
 
     heldNotesDidChange();
-    playingNotesDidChange();
 }


### PR DESCRIPTION
Remove additional playingNotesDidChange calls from turnon/offkey.
I believe this would occasionally cause stuck notes in the UI due
to potential double notifications within one render-loop.
(and may be a source for crashing the AEMessageQueue)

@aure I added you to this because I saw you added it back then. Not sure if there was any particular reason for these additional notifications, at least in my tests it didnt make a difference.


**Release Note**
- Fixed a bug that would occasionally cause notes to be displayed as playing in the UI when they are not.