### PR TITLE
Keep weak reference to S1AudioUnit

### DIFF
--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
@@ -183,7 +183,7 @@ public:
     float taper(float inputValue01, float min, float max, float taper);
     float taperInverse(float inputValue01, float min, float max, float taper);
 
-    S1AudioUnit* audioUnit;
+    __weak S1AudioUnit* audioUnit;
     
     bool resetted = false;
     


### PR DESCRIPTION
We are having a retain cycle here. AudioUnit retains the DSPKernel,
and the DSPKernel retains the Audiounit. Thus these will never properly deallocate.

@aure @marcussatellite : while trying to get to the root of the AEMessageQueue issues, I found this little issue. It probably doesnt change much for the user because S1AudioUnit and the DSPKernel are almost always alive.