### PR TITLE
Do not select empty preset banks

### DIFF
--- a/AudioKitSynthOne/Presets/PresetsViewController/Presets+LoadSaveManipulate.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/Presets+LoadSaveManipulate.swift
@@ -347,6 +347,8 @@ extension PresetsViewController {
         guard let currentBank = conductor.banks.first(where: { $0.position == bankIndex }) else { return }
         let presetsInBank = presets.filter { $0.bank == currentBank.name }.sorted { $0.position < $1.position }
 
+        if (presetsInBank.count == 0) { return }
+
         // Smoothly cycle through presets if MIDI input is greater than preset count
         let currentPresetIndex = index % (presetsInBank.count)
 


### PR DESCRIPTION
**Release Note**: Fixed a bug that could lead to a crash when selecting Presets through MIDI CC.

-----
In this report that came in through MS AppCenter presets
can be selected via MIDI CC. Unfortunately also banks
with zero presets can get chosen which is where the modulo
zero operation is triggered that ultimately leads to a crash.;

Can't think of a good solution to this right now, so I'm patching
this up with an early return.

@marcussatellite @analogcode this is one from our MS App Center crashes.
@aure I think this one might be in D1 as well.