### PR TITLE
Fix reference count for Held Notes

### DIFF
--- a/AudioKitSynthOne/DSP/Sequencer/S1Sequencer.mm
+++ b/AudioKitSynthOne/DSP/Sequencer/S1Sequencer.mm
@@ -36,7 +36,7 @@ void S1Sequencer::reset(bool resetNotes) {
     sequencerNotes2.clear();
 }
 
-void S1Sequencer::process(DSPParameters &params, AEArray *heldNoteNumbersAE) {
+void S1Sequencer::process(DSPParameters &params, __weak AEArray *heldNoteNumbersAE) {
     
     /// MARK: ARPEGGIATOR + SEQUENCER BEGIN
     const int heldNoteNumbersAECount = heldNoteNumbersAE.count;


### PR DESCRIPTION
**Release Note**: Bug fixes and performance improvements 😄 (honestly, I wouldn't put this in the notes, it would improve performance a bit, but i doubt its significantly)

-----
AEArray is technically still an Objective C object, by not
using the __weak prefix we were increasing/decreasing the ref
count each time we passed this object in.