### PR TITLE
Setup Parameter Tree in DSPKernel constructor

### DIFF
--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
@@ -232,6 +232,9 @@ private:
     // private tuningTable lookup
     double tuningTableNoteToHz(int noteNumber);
 
+    // setup parameter tree with values or default
+    void setupParameterTree(std::optional<DSPParameters> params);
+
     S1Rate _rate;
     
     DependentParameter _lfo1Rate;

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.mm
@@ -24,7 +24,11 @@ S1DSPKernel::S1DSPKernel(int _channels, double _sampleRate) :
     mCompReverbWet(sp, &parameters),
     mCompReverbIn(sp, &parameters)
 {
-    init(_channels, _sampleRate);
+    for(int i = 0; i< S1Parameter::S1ParameterCount; i++) {
+        sp_port_create(&s1p[i].portamento);
+    }
+
+    setupParameterTree(std::nullopt);
 }
 
 S1DSPKernel::~S1DSPKernel() = default;
@@ -92,9 +96,7 @@ void S1DSPKernel::init(int _channels, double _sampleRate) {
     sequencer.setSampleRate(_sampleRate);
     sequencer.init();
 
-    for(int i = 0; i< S1Parameter::S1ParameterCount; i++) {
-        sp_port_create(&s1p[i].portamento);
-    }
+
     _rate.init();
 
     // intialize dsp tuning table with 12ET
@@ -106,8 +108,7 @@ void S1DSPKernel::init(int _channels, double _sampleRate) {
     restoreValues(std::nullopt);
 }
 
-void S1DSPKernel::restoreValues(std::optional<DSPParameters> params) {
-
+void S1DSPKernel::setupParameterTree(std::optional<DSPParameters> params) {
     // copy dsp values or initialize with default
     for(int i = 0; i< S1Parameter::S1ParameterCount; i++) {
         const float value = (params != std::nullopt) ? (*params)[i] : defaultValue((S1Parameter)i);
@@ -118,6 +119,11 @@ void S1DSPKernel::restoreValues(std::optional<DSPParameters> params) {
         }
         parameters[i] = value;
     }
+}
+
+void S1DSPKernel::restoreValues(std::optional<DSPParameters> params) {
+
+    setupParameterTree(params);
     updatePortamento(parameters[portamentoHalfTime]);
     _lfo1Rate = {S1Parameter::lfo1Rate, getDependentParameter(lfo1Rate), getSynthParameter(lfo1Rate),0};
     _lfo2Rate = {S1Parameter::lfo2Rate, getDependentParameter(lfo2Rate), getSynthParameter(lfo2Rate),0};


### PR DESCRIPTION
Setup the parameter tree and defaults when we instantiate
the kernel instead of calling init.
Init is called a second time in `allocateRenderResourcesAndReturnError` in `S1AudioUnit.m`
without destroying the SoundPipe objects therefore resulting in a memory leak.
According to Apple's documentation `allocateRenderResourcesAndReturnError` is the place where we are supposed to allocate all the DSP stuff.

Fixes top of instantiation memory leaks:
![Screenshot 2019-05-28 at 23 28 43](https://user-images.githubusercontent.com/5174440/58513705-61f97680-81a0-11e9-8d63-9da4129e34e4.png)


ping @aure @analogcode @marcussatellite 