### PR TITLE
Fix Crash on deallocation of render resources

### DIFF
--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+destroy.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+destroy.mm
@@ -34,6 +34,7 @@ void S1DSPKernel::destroy() {
     sp_buthp_destroy(&butterworthHipassR);
     sp_crossfade_destroy(&revCrossfadeL);
     sp_crossfade_destroy(&revCrossfadeR);
+    mIsInitialized = false;
 }
 
 

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
@@ -165,6 +165,9 @@ private:
     S1Sequencer sequencer;
     // moved the private functions to try to get rid of errors, I don't think we need to be that worried about privacy
 
+    // Keep track on when and when not to call destroy()
+    bool mIsInitialized = false;
+
 public:
     
     void updateWavetableIncrementValuesForCurrentSampleRate();

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.mm
@@ -24,18 +24,22 @@ S1DSPKernel::S1DSPKernel(int _channels, double _sampleRate) :
     mCompReverbWet(sp, &parameters),
     mCompReverbIn(sp, &parameters)
 {
-    for(int i = 0; i< S1Parameter::S1ParameterCount; i++) {
-        sp_port_create(&s1p[i].portamento);
-    }
-
-    setupParameterTree(std::nullopt);
+    init(_channels, _sampleRate);
 }
 
 S1DSPKernel::~S1DSPKernel() = default;
 
 void S1DSPKernel::init(int _channels, double _sampleRate) {
+    if (mIsInitialized) {
+      destroy();
+    }
     sp->sr = _sampleRate;
     sp->nchan = _channels;
+
+    for(int i = 0; i< S1Parameter::S1ParameterCount; i++) {
+      sp_port_create(&s1p[i].portamento);
+    }
+    setupParameterTree(std::nullopt);
 
     //MONO
     sp_ftbl_create(sp, &sine, S1_FTABLE_SIZE);
@@ -106,6 +110,7 @@ void S1DSPKernel::init(int _channels, double _sampleRate) {
 
     // restore values
     restoreValues(std::nullopt);
+    mIsInitialized = true;
 }
 
 void S1DSPKernel::setupParameterTree(std::optional<DSPParameters> params) {


### PR DESCRIPTION
Fix a crash that will occur when headphones are unplugged
on certain iOS Devices.
This was introduced earlier when trying to fix memory leaks,
unfortunately we are running into a double-free situation with
the C objects now.
We're now instead tracking state of the kernel initialization
in order to avoid those memory leaks.

ping @aure @marcussatellite @analogcode 
Seems like I wasn't careful enough in https://github.com/AudioKit/AudioKitSynthOne/pull/84