### PR TITLE
Fix: Restore Polyphonic mode

### DIFF
--- a/AudioKitSynthOne/Manager/Manager.swift
+++ b/AudioKitSynthOne/Manager/Manager.swift
@@ -469,7 +469,7 @@ public class Manager: UpdatableViewController {
         let isMono = s.getSynthParameter(.isMono)
         if isMono != monoButton.value {
             monoButton.value = isMono
-            self.keyboardView.polyphonicMode = (isMono == 0) ? false : true
+            self.keyboardView.polyphonicMode = (isMono == 0) ? true : false
         }
         
         if parameter == .cutoff {


### PR DESCRIPTION
Fix the logic bug introduced in https://github.com/AudioKit/AudioKitSynthOne/commit/10bb67f91f547df22c0cf7bd74732a7da90dd98e to restore polyphonic mode.

ping @marcussatellite @analogcode  - maybe give this a test run :)