### PR TITLE
Fix: Add missing ADSR initialization

### DIFF
--- a/AudioKitSynthOne.xcodeproj/project.pbxproj
+++ b/AudioKitSynthOne.xcodeproj/project.pbxproj
@@ -2345,7 +2345,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 51EC225D22B5EE94B01AA474 /* Pods-AudioKitSynthOne.debug.xcconfig */;
 			buildSettings = {
-				ABLETON_ENABLED = 1;
+				ABLETON_ENABLED = 0;
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -2387,7 +2387,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E2883EE9358887836A57FE08 /* Pods-AudioKitSynthOne.release.xcconfig */;
 			buildSettings = {
-				ABLETON_ENABLED = 1;
+				ABLETON_ENABLED = 0;
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;

--- a/AudioKitSynthOne/DSP/Note State/S1NoteState.mm
+++ b/AudioKitSynthOne/DSP/Note State/S1NoteState.mm
@@ -117,6 +117,9 @@ void S1NoteState::startNoteHelper(int noteNumber, int vel, float frequency) {
     subOsc->freq = frequency;
     fmOsc->freq = frequency;
 
+    sp_adsr_init(kernel->spp(), adsr);
+    sp_adsr_init(kernel->spp(), fadsr);
+
     velocity = vel;
     const float amplitude = (float)pow2(velocity / 127.f);
     oscmorph1->amp = amplitude;


### PR DESCRIPTION
**Release Notes:** Sequencer is now retriggering notes of the same key in poly mode as expected.

-------
When we are doing note stealing and using this helper
we should also reinitialize the ADSR curves or else we would
be in release land forever.

@analogcode @marcussatellite 