### PR TITLE
RFC: Replace Soundpipe Moog Ladder with S1DSP Version

### DIFF
--- a/AudioKitSynthOne.xcodeproj/project.pbxproj
+++ b/AudioKitSynthOne.xcodeproj/project.pbxproj
@@ -286,6 +286,7 @@
 		45E1A7C3C54D27427C4A71B1 /* Pods_AKS1Extension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AKS1Extension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		51EC225D22B5EE94B01AA474 /* Pods-AudioKitSynthOne.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AudioKitSynthOne.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AudioKitSynthOne/Pods-AudioKitSynthOne.debug.xcconfig"; sourceTree = "<group>"; };
 		5FAA47B316A5F659F440DAC9 /* Pods-AKS1Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AKS1Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AKS1Extension/Pods-AKS1Extension.debug.xcconfig"; sourceTree = "<group>"; };
+		69A881EA22ABB21600217688 /* S1DSPMoogLadder.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = S1DSPMoogLadder.hpp; sourceTree = "<group>"; };
 		69E4E45622381DF90049F0EA /* S1DSPCompressor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = S1DSPCompressor.hpp; sourceTree = "<group>"; };
 		90231BFB16779C7C2CD6CB3F /* Pods-AKS1Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AKS1Extension.release.xcconfig"; path = "Pods/Target Support Files/Pods-AKS1Extension/Pods-AKS1Extension.release.xcconfig"; sourceTree = "<group>"; };
 		9405503A210556C20039F101 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
@@ -1030,6 +1031,7 @@
 			isa = PBXGroup;
 			children = (
 				69E4E45622381DF90049F0EA /* S1DSPCompressor.hpp */,
+				69A881EA22ABB21600217688 /* S1DSPMoogLadder.hpp */,
 				C435C57720C530C900DAECCD /* S1DSPKernel.hpp */,
 				C435C57620C530C900DAECCD /* S1DSPKernel.mm */,
 				C4B490E520C649D900FD565A /* S1DSPKernel+destroy.mm */,
@@ -1681,7 +1683,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AudioKitSynthOne/Pods-AudioKitSynthOne-frameworks.sh",
+				"${SRCROOT}/Pods/Target Support Files/Pods-AudioKitSynthOne/Pods-AudioKitSynthOne-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/ChimpKit/ChimpKit.framework",
 				"${BUILT_PRODUCTS_DIR}/Disk/Disk.framework",
 			);
@@ -1692,7 +1694,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AudioKitSynthOne/Pods-AudioKitSynthOne-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AudioKitSynthOne/Pods-AudioKitSynthOne-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		C4421AA920B81D0500BE9F12 /* ShellScript */ = {
@@ -2355,6 +2357,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 9W69ZP8S5F;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = AudioKitSynthOne/Info.plist;

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+destroy.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+destroy.mm
@@ -21,8 +21,6 @@ void S1DSPKernel::destroy() {
     sp_phaser_destroy(&phaser0);
     sp_osc_destroy(&panOscillator);
     sp_pan2_destroy(&pan);
-    sp_moogladder_destroy(&loPassInputDelayL);
-    sp_moogladder_destroy(&loPassInputDelayR);
     sp_vdelay_destroy(&delayL);
     sp_vdelay_destroy(&delayR);
     sp_vdelay_destroy(&delayRR);

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+process.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+process.mm
@@ -219,12 +219,12 @@ void S1DSPKernel::process(AUAudioFrameCount frameCount, AUAudioFrameCount buffer
             const float oscFilterResonance = 0.f; // constant
             float oscFilterFreqCutoff = pval1 * oscFilterFreqCutoffPercentage;
             oscFilterFreqCutoff = clampedValue(cutoff, oscFilterFreqCutoff);
-            loPassInputDelayL->freq = oscFilterFreqCutoff;
-            loPassInputDelayL->res = oscFilterResonance;
-            loPassInputDelayR->freq = oscFilterFreqCutoff;
-            loPassInputDelayR->res = oscFilterResonance;
-            sp_moogladder_compute(sp, loPassInputDelayL, &phaserOutL, &delayInputLowPassOutL);
-            sp_moogladder_compute(sp, loPassInputDelayR, &phaserOutR, &delayInputLowPassOutR);
+            loPassInputDelayL.setCutoff(oscFilterFreqCutoff);
+            loPassInputDelayL.setResonance(oscFilterResonance);
+            loPassInputDelayR.setCutoff(oscFilterFreqCutoff);
+            loPassInputDelayR.setResonance(oscFilterResonance);
+            delayInputLowPassOutL = loPassInputDelayL.process(phaserOutL);
+            delayInputLowPassOutR = loPassInputDelayR.process(phaserOutR);
         }
 
         // PING PONG DELAY

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.hpp
@@ -20,6 +20,7 @@
 #import "S1Rate.hpp"
 #import "../Sequencer/S1Sequencer.hpp"
 #import "S1DSPCompressor.hpp"
+#import "S1DSPMoogLadder.hpp"
 
 @class AEArray;
 @class AEMessageQueue;
@@ -300,8 +301,8 @@ private:
     sp_osc *panOscillator;
     sp_phaser *phaser0;
     
-    sp_moogladder *loPassInputDelayL;
-    sp_moogladder *loPassInputDelayR;
+    S1DSPMoogLadder loPassInputDelayL;
+    S1DSPMoogLadder loPassInputDelayR;
     sp_vdelay *delayL;
     sp_vdelay *delayR;
     sp_vdelay *delayRR;

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel.mm
@@ -63,10 +63,8 @@ void S1DSPKernel::init(int _channels, double _sampleRate) {
     sp_pan2_init(sp, pan);
 
     //STEREO
-    sp_moogladder_create(&loPassInputDelayL);
-    sp_moogladder_init(sp, loPassInputDelayL);
-    sp_moogladder_create(&loPassInputDelayR);
-    sp_moogladder_init(sp, loPassInputDelayR);
+    loPassInputDelayL = S1DSPMoogLadder(_sampleRate);
+    loPassInputDelayR = S1DSPMoogLadder(_sampleRate);
     sp_vdelay_create(&delayL);
     sp_vdelay_create(&delayR);
     sp_vdelay_create(&delayRR);
@@ -152,10 +150,10 @@ void S1DSPKernel::restoreValues(std::optional<DSPParameters> params) {
     *phaser0->invert = 0;
     *phaser0->lfobpm = 30;
 
-    loPassInputDelayL->freq = getSynthParameter(cutoff);
-    loPassInputDelayL->res = getSynthParameter(delayInputResonance);
-    loPassInputDelayR->freq = getSynthParameter(cutoff);
-    loPassInputDelayR->res = getSynthParameter(delayInputResonance);
+    loPassInputDelayL.setCutoff(getSynthParameter(cutoff));
+    loPassInputDelayL.setResonance(getSynthParameter(delayInputResonance));
+    loPassInputDelayR.setCutoff(getSynthParameter(cutoff));
+    loPassInputDelayR.setResonance(getSynthParameter(delayInputResonance));
 
     // Reserve arp note cache to reduce possibility of reallocation on audio thread.
     sequencer.init();

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPMoogLadder.hpp
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPMoogLadder.hpp
@@ -1,0 +1,108 @@
+// Based on implementation in CSound5 (LGPLv2.1)
+// https://github.com/csound/csound/blob/develop/COPYING
+
+#pragma once
+
+#define MOOG_PI        3.14159265358979323846264338327950288
+
+class S1DSPMoogLadder
+{
+ 
+  /* John ffitch tanh function to speed up inner loop */
+
+  static double my_tanh(double x)
+  {
+    /* use the fact that tanh(-x) = - tanh(x)
+     and if x>~4 tanh is approx constant 1
+     and for small x tanh(x) =~ x
+     So giving a cheap approximation */
+    int sign = 1;
+    if (x<0) {
+      sign=-1;
+      x= -x;
+    }
+    if (x>=4.0) {
+      return sign;
+    }
+    if (x<0.5) return x*sign;
+    return sign*tanh(x);
+  }
+
+public:
+  S1DSPMoogLadder(float sampleRate) :
+    sampleRate(sampleRate), thermal(0.000025)
+  {
+    memset(stage, 0, sizeof(stage));
+    memset(delay, 0, sizeof(delay));
+    memset(stageTanh, 0, sizeof(stageTanh));
+    setCutoff(1000.0f);
+    setResonance(0.10f);
+  }
+  
+  S1DSPMoogLadder()
+  {
+    
+  }
+  
+  float process(float sample)
+  {
+      // Oversample
+      for (int j = 0; j < 2; j++)
+      {
+        float input = sample - resQuad * delay[5];
+        delay[0] = stage[0] = delay[0] + tune * (my_tanh(input * thermal) - stageTanh[0]);
+        for (int k = 1; k < 4; k++)
+        {
+          input = stage[k-1];
+          stage[k] = delay[k] + tune * ((stageTanh[k-1] = my_tanh(input * thermal)) - (k != 3 ? stageTanh[k] : my_tanh(delay[k] * thermal)));
+          delay[k] = stage[k];
+        }
+        // 0.5 sample delay for phase compensation
+        delay[5] = (stage[3] + delay[4]) * 0.5;
+        delay[4] = stage[3];
+      }
+      return delay[5];
+  }
+  
+  void setResonance(float r)
+  {
+    if (resonance == r) {
+        return;
+    }
+    resonance = r;
+    resQuad = 4.0 * resonance * acr;
+  }
+  
+  void setCutoff(float c)
+  {
+    if (cutoff == c) {
+        return;
+    }
+    cutoff = c;
+    
+    double fc =  cutoff / sampleRate;
+    double f  =  fc * 0.5; // oversampled
+    double fc2 = fc * fc;
+    double fc3 = fc * fc * fc;
+    
+    double fcr = 1.8730 * fc3 + 0.4955 * fc2 - 0.6490 * fc + 0.9988;
+    acr = -3.9364 * fc2 + 1.8409 * fc + 0.9968;
+    
+    tune = (1.0 - exp(-((2 * MOOG_PI) * f * fcr))) / thermal;
+    
+    setResonance(resonance);
+  }
+  
+private:
+  double stage[4];
+  double stageTanh[3];
+  double delay[6];
+  float cutoff;
+  float resonance;
+  float sampleRate;
+  
+  double thermal;
+  double tune;
+  double acr;
+  double resQuad;
+};

--- a/AudioKitSynthOne/DSP/Note State/S1NoteState.hpp
+++ b/AudioKitSynthOne/DSP/Note State/S1NoteState.hpp
@@ -14,6 +14,7 @@
 #import <string>
 #import "AudioKit/AKSoundpipeKernel.hpp"
 #import "S1AudioUnit.h"
+#import "S1DSPMoogLadder.hpp"
 #import "S1Parameter.h"
 #import "S1Rate.hpp"
 
@@ -66,7 +67,7 @@ struct S1NoteState {
     sp_noise *noise;
     
     //FILTERS
-    sp_moogladder *loPass;
+    S1DSPMoogLadder loPass;
     sp_buthp *hiPass;
     sp_butbp *bandPass;
     sp_crossfade *filterCrossFade;


### PR DESCRIPTION
Posting this as an RFC.

------
# Benchmarks

### Compiler Settings & Benchmark Scenario

All profiling was done under the same circumstances.
AudioKit SDK through CocoaPods is compiled with `-0s (Fastest, Smallest)` even for Debug builds, so in order to replicate, same had to be done with SynthOne.

For playback, I used a 3-Note held Chord with the sequencer activated to increase polyphony.

### CPU Usage
SoundPipe Moog Ladder: ~36-43%
S1DSPMoogLadder: ~27-35%

### Instruments
***SoundPipe***
![Screenshot 2019-06-08 at 12 04 48](https://user-images.githubusercontent.com/5174440/59145547-a6c5ae80-89e5-11e9-8ec4-13ea4b6ac408.png)

***S1DSPMoogLadder***
![Screenshot 2019-06-08 at 12 04 37](https://user-images.githubusercontent.com/5174440/59145549-afb68000-89e5-11e9-9375-e149d0ca0754.png)

# Discussion

The sound is pretty much he same, because of identical sources for the algorithms.
In both modules `tanh` calculation is the most expensive operation, and it seems like the one in @PaulBatchelor s implementation is actually the cheapest available. Alternatives like `vox_fasttanh` (as discussed [here](https://www.kvraudio.com/forum/viewtopic.php?t=388650&postdays=0&postorder=asc&start=45)) are in fact slower (but may lead to slightly better sound).

The slightly better CPU performance of this new filter is presumably because of fewer calculations for Cutoff/Resonance parameters on each sample and a less complex call-hierarchy (no calls to the kernel to access the SoundPipe Kernel).

@aure @analogcode @marcussatellite @PaulBatchelor feel free to play around with this. I'll leave it open for discussion whether we should merge this or not.
I've attached the Instruments Profiling results at the bottom.

[1_old_2_new.trace.zip](https://github.com/AudioKit/AudioKitSynthOne/files/3268413/1_old_2_new.trace.zip)
