### PR TITLE
Prevent startup crash

### DIFF
--- a/AudioKitSynthOne/Generators/GeneratorsPanelController.swift
+++ b/AudioKitSynthOne/Generators/GeneratorsPanelController.swift
@@ -186,38 +186,28 @@ class GeneratorsPanelController: PanelController {
     }
     
     override func updateUI(_ parameter: S1Parameter, control: S1Control?, value: Double) {
-        switch parameter {
-        case .filterType:
-            switch value {
-            case 0:
-                // Low Pass
-                if (cutoffKnobLabel != nil) {
+        if (cutoffKnobLabel != nil && rezKnobLabel != nil) {
+            switch parameter {
+            case .filterType:
+                switch value {
+                case 0:
+                    // Low Pass
                     cutoffKnobLabel.text = "Frequency"
-                }
-                if (rezKnobLabel != nil) {
                     rezKnobLabel.text = "Resonance"
-                }
-            case 1:
-                // Band Pass
-                if (cutoffKnobLabel != nil) {
+                case 1:
+                    // Band Pass
                     cutoffKnobLabel.text = "Center"
-                }
-                if (rezKnobLabel != nil) {
                     rezKnobLabel.text = "Width"
-                }
-            case 2:
-                // High Pass
-                if (cutoffKnobLabel != nil) {
+                case 2:
+                    // High Pass
                     cutoffKnobLabel.text = "Frequency"
-                }
-                if (rezKnobLabel != nil) {
                     rezKnobLabel.text = "Off"
+                default:
+                    break
                 }
             default:
-                break
+                _ = 0
             }
-        default:
-            _ = 0
         }
     }
 }

--- a/AudioKitSynthOne/Generators/GeneratorsPanelController.swift
+++ b/AudioKitSynthOne/Generators/GeneratorsPanelController.swift
@@ -12,6 +12,10 @@ import UIKit
 
 class GeneratorsPanelController: PanelController {
 
+    @IBOutlet weak var cutoffKnobLabel: UILabel!
+    
+    @IBOutlet weak var rezKnobLabel: UILabel!
+    
     @IBOutlet weak var morph1Selector: MorphSelector!
 
     @IBOutlet weak var morph2Selector: MorphSelector!
@@ -63,10 +67,6 @@ class GeneratorsPanelController: PanelController {
     @IBOutlet weak var widenToggle: FlatToggleButton!
 
     @IBOutlet weak var oscBandlimitEnable: ToggleButton!
-    
-    @IBOutlet weak var cutoffKnobLabel: UILabel!
-    
-    @IBOutlet weak var rezKnobLabel: UILabel!
     
     var audioPlot: AKNodeOutputPlot!
 
@@ -191,16 +191,28 @@ class GeneratorsPanelController: PanelController {
             switch value {
             case 0:
                 // Low Pass
-                cutoffKnobLabel.text = "Frequency"
-                rezKnobLabel.text = "Resonance"
+                if (cutoffKnobLabel != nil) {
+                    cutoffKnobLabel.text = "Frequency"
+                }
+                if (rezKnobLabel != nil) {
+                    rezKnobLabel.text = "Resonance"
+                }
             case 1:
                 // Band Pass
-                cutoffKnobLabel.text = "Center"
-                rezKnobLabel.text = "Width"
+                if (cutoffKnobLabel != nil) {
+                    cutoffKnobLabel.text = "Center"
+                }
+                if (rezKnobLabel != nil) {
+                    rezKnobLabel.text = "Width"
+                }
             case 2:
                 // High Pass
-                cutoffKnobLabel.text = "Frequency"
-                rezKnobLabel.text = "Off"
+                if (cutoffKnobLabel != nil) {
+                    cutoffKnobLabel.text = "Frequency"
+                }
+                if (rezKnobLabel != nil) {
+                    rezKnobLabel.text = "Off"
+                }
             default:
                 break
             }


### PR DESCRIPTION
I could no longer debug the current develop branch on an Iphone XS 12.2 Simulator - keep getting Thread 1: Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value in GeneratorsPanelController.swift line 194

Problem with this commit? e98c53ec  Update Filter Knob Labels when FilterType changes - cutoffKnobLabel text was being set before the control was initialised

As ever there is probably a better way to fix this but it worked for me...