### PR TITLE
Add NSBluetoothAlwaysUsageDescription

### DIFF
--- a/AudioKitSynthOne/Info.plist
+++ b/AudioKitSynthOne/Info.plist
@@ -133,6 +133,8 @@
 	<true/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Synth One needs access to Bluetooth to connect to wireless MIDI Devices.</string>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Add description required by iOS 13 to tell users why
we want access to Bluetooth.