### PR TITLE
WIP: MacOS Cataylst Documentation

### DIFF
--- a/AudioKitSynthOne.xcodeproj/project.pbxproj
+++ b/AudioKitSynthOne.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		48C3EE7437FA1B1E7916844E /* Pods_AudioKitSynthOne.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA27CDAC229BF66A1C649B42 /* Pods_AudioKitSynthOne.framework */; };
 		69115F3E2363BBA100B144A5 /* Conductor+Audiobus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69115F3D2363BBA000B144A5 /* Conductor+Audiobus.swift */; };
+		69C11CF7236C96DA00833BF7 /* MailchimpService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690F807A236B5B9D00FDC518 /* MailchimpService.swift */; };
+		69C11CF8236C96DC00833BF7 /* MD5Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C11CF3236C375B00833BF7 /* MD5Helpers.swift */; };
 		941645CD20B3597300D62851 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941645CC20B3597300D62851 /* NotificationService.swift */; };
 		941645D120B3597300D62851 /* OneSignalNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 941645CA20B3597300D62851 /* OneSignalNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		941752BA20E2BD2E0076D953 /* Starter Bank.json in Resources */ = {isa = PBXBuildFile; fileRef = 941752B920E2BD2E0076D953 /* Starter Bank.json */; };
@@ -298,7 +300,10 @@
 		45E1A7C3C54D27427C4A71B1 /* Pods_AKS1Extension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AKS1Extension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		51EC225D22B5EE94B01AA474 /* Pods-AudioKitSynthOne.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AudioKitSynthOne.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AudioKitSynthOne/Pods-AudioKitSynthOne.debug.xcconfig"; sourceTree = "<group>"; };
 		5FAA47B316A5F659F440DAC9 /* Pods-AKS1Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AKS1Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AKS1Extension/Pods-AKS1Extension.debug.xcconfig"; sourceTree = "<group>"; };
+		690F807A236B5B9D00FDC518 /* MailchimpService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailchimpService.swift; sourceTree = "<group>"; };
 		69115F3D2363BBA000B144A5 /* Conductor+Audiobus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Conductor+Audiobus.swift"; sourceTree = "<group>"; };
+		69C11CE4236C2F3700833BF7 /* AudioKit For iOS.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "AudioKit For iOS.xcodeproj"; path = "../AudioKit/AudioKit/iOS/AudioKit For iOS.xcodeproj"; sourceTree = "<group>"; };
+		69C11CF3236C375B00833BF7 /* MD5Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MD5Helpers.swift; sourceTree = "<group>"; };
 		69E4E45622381DF90049F0EA /* S1DSPCompressor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = S1DSPCompressor.hpp; sourceTree = "<group>"; };
 		90231BFB16779C7C2CD6CB3F /* Pods-AKS1Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AKS1Extension.release.xcconfig"; path = "Pods/Target Support Files/Pods-AKS1Extension/Pods-AKS1Extension.release.xcconfig"; sourceTree = "<group>"; };
 		9405503A210556C20039F101 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
@@ -1255,6 +1260,8 @@
 			children = (
 				EA388CFB2104995B0026C0C0 /* MailingList.storyboard */,
 				C4B4919620C7C81200FD565A /* Manager+MailingListDelegate.swift */,
+				690F807A236B5B9D00FDC518 /* MailchimpService.swift */,
+				69C11CF3236C375B00833BF7 /* MD5Helpers.swift */,
 				C4B4919720C7C81200FD565A /* MailingListViewController.swift */,
 			);
 			path = "Mailing List";
@@ -1834,6 +1841,7 @@
 				94189CB8219F27130004C28B /* MoreAppsController.swift in Sources */,
 				C4B4914020C7C6A000FD565A /* TouchPointStyleKit.swift in Sources */,
 				C435C4F820C5234900DAECCD /* CategoryCell.swift in Sources */,
+				69C11CF8236C96DC00833BF7 /* MD5Helpers.swift in Sources */,
 				C435C53120C52D4C00DAECCD /* Tunings+Math.swift in Sources */,
 				C435C58520C530C900DAECCD /* S1AudioUnit.mm in Sources */,
 				C4B4919020C7C7B200FD565A /* BankEditorViewController.swift in Sources */,
@@ -1948,6 +1956,7 @@
 				F473515722A0D63900869AFB /* TuningsViewController.swift in Sources */,
 				C45DF29C21016A0E000AB3FD /* LinkExtensions.swift in Sources */,
 				C4B4918E20C7C7A400FD565A /* Manager+PresetsDelegate.swift in Sources */,
+				69C11CF7236C96DA00833BF7 /* MailchimpService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AudioKitSynthOne.xcodeproj/project.pbxproj
+++ b/AudioKitSynthOne.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		48C3EE7437FA1B1E7916844E /* Pods_AudioKitSynthOne.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA27CDAC229BF66A1C649B42 /* Pods_AudioKitSynthOne.framework */; };
 		69115F3E2363BBA100B144A5 /* Conductor+Audiobus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69115F3D2363BBA000B144A5 /* Conductor+Audiobus.swift */; };
+		6982467D236EDCE600407DF4 /* Conductor+Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6982467C236EDCE600407DF4 /* Conductor+Platform.swift */; };
 		69C11CF7236C96DA00833BF7 /* MailchimpService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690F807A236B5B9D00FDC518 /* MailchimpService.swift */; };
 		69C11CF8236C96DC00833BF7 /* MD5Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C11CF3236C375B00833BF7 /* MD5Helpers.swift */; };
 		941645CD20B3597300D62851 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941645CC20B3597300D62851 /* NotificationService.swift */; };
@@ -302,6 +303,7 @@
 		5FAA47B316A5F659F440DAC9 /* Pods-AKS1Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AKS1Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AKS1Extension/Pods-AKS1Extension.debug.xcconfig"; sourceTree = "<group>"; };
 		690F807A236B5B9D00FDC518 /* MailchimpService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailchimpService.swift; sourceTree = "<group>"; };
 		69115F3D2363BBA000B144A5 /* Conductor+Audiobus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Conductor+Audiobus.swift"; sourceTree = "<group>"; };
+		6982467C236EDCE600407DF4 /* Conductor+Platform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Conductor+Platform.swift"; sourceTree = "<group>"; };
 		69C11CE4236C2F3700833BF7 /* AudioKit For iOS.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "AudioKit For iOS.xcodeproj"; path = "../AudioKit/AudioKit/iOS/AudioKit For iOS.xcodeproj"; sourceTree = "<group>"; };
 		69C11CF3236C375B00833BF7 /* MD5Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MD5Helpers.swift; sourceTree = "<group>"; };
 		69E4E45622381DF90049F0EA /* S1DSPCompressor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = S1DSPCompressor.hpp; sourceTree = "<group>"; };
@@ -1005,6 +1007,7 @@
 				F437E99E20EB22D00096FEAC /* README.md */,
 				C435C55420C530C900DAECCD /* AKSynthOne.swift */,
 				C435C55120C530C900DAECCD /* Conductor.swift */,
+				6982467C236EDCE600407DF4 /* Conductor+Platform.swift */,
 				F4B1AD64228BDCEC009FA6BA /* S1TuningTable.swift */,
 				F4CA406C224EB2A70053F29E /* S1Control.swift */,
 				C435C55320C530C900DAECCD /* S1Parameter.h */,
@@ -1822,6 +1825,7 @@
 				C4B491A120C7C91A00FD565A /* EnvelopesPanelController.swift in Sources */,
 				94F7846722D3FE8400C35702 /* SearchViewController.swift in Sources */,
 				94D917AD1F550D0E006ACB4E /* FlatToggleButtonStyleKit.swift in Sources */,
+				6982467D236EDCE600407DF4 /* Conductor+Platform.swift in Sources */,
 				F40636FF22E3EECB00A422D3 /* KeyboardView+Draw12ET.swift in Sources */,
 				C432979320CB2BB20063F795 /* Presets+LoadSaveManipulate.swift in Sources */,
 				F491FC5422DF8BDF00CDB78E /* Tunings+Drawing.swift in Sources */,

--- a/AudioKitSynthOne.xcodeproj/project.pbxproj
+++ b/AudioKitSynthOne.xcodeproj/project.pbxproj
@@ -1726,12 +1726,10 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AudioKitSynthOne/Pods-AudioKitSynthOne-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/ChimpKit/ChimpKit.framework",
 				"${BUILT_PRODUCTS_DIR}/Disk/Disk.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ChimpKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Disk.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AudioKitSynthOne/About/Mailing List/MD5Helpers.swift
+++ b/AudioKitSynthOne/About/Mailing List/MD5Helpers.swift
@@ -1,0 +1,112 @@
+//
+//  MD5Helpers.swift
+//  AudioKitSynthOne
+//
+//  Created by Matthias Frick on 01/11/2019.
+//  Copyright © 2019 AudioKit. All rights reserved.
+//
+
+import Foundation
+import CommonCrypto
+
+// Helper function to create MD5 Hash
+// Needed for adressing endpoints in MailChimp API v3
+
+// Defines types of hash string outputs available
+public enum HashOutputType {
+    case hex
+    case base64
+}
+
+// Defines types of hash algorithms available
+public enum HashType {
+    case md5
+    case sha1
+    case sha224
+    case sha256
+    case sha384
+    case sha512
+
+    var length: Int32 {
+        switch self {
+        case .md5: return CC_MD5_DIGEST_LENGTH
+        case .sha1: return CC_SHA1_DIGEST_LENGTH
+        case .sha224: return CC_SHA224_DIGEST_LENGTH
+        case .sha256: return CC_SHA256_DIGEST_LENGTH
+        case .sha384: return CC_SHA384_DIGEST_LENGTH
+        case .sha512: return CC_SHA512_DIGEST_LENGTH
+        }
+    }
+}
+
+public extension String {
+
+    /// Hashing algorithm for hashing a string instance.
+    ///
+    /// - Parameters:
+    ///   - type: The type of hash to use.
+    ///   - output: The type of output desired, defaults to .hex.
+    /// - Returns: The requested hash output or nil if failure.
+    func hashed(_ type: HashType, output: HashOutputType = .hex) -> String? {
+        // convert string to utf8 encoded data
+        guard let message = data(using: .utf8) else { return nil }
+        return message.hashed(type, output: output)
+    }
+}
+
+extension Data {
+
+    /// Hashing algorithm that prepends an RSA2048ASN1Header to the beginning of the data being hashed.
+    ///
+    /// - Parameters:
+    ///   - type: The type of hash algorithm to use for the hashing operation.
+    ///   - output: The type of output string desired.
+    /// - Returns: A hash string using the specified hashing algorithm, or nil.
+    public func hashWithRSA2048Asn1Header(_ type: HashType, output: HashOutputType = .hex) -> String? {
+
+        let rsa2048Asn1Header:[UInt8] = [
+            0x30, 0x82, 0x01, 0x22, 0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86,
+            0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00, 0x03, 0x82, 0x01, 0x0f, 0x00
+        ]
+
+        var headerData = Data(rsa2048Asn1Header)
+        headerData.append(self)
+
+        return hashed(type, output: output)
+    }
+
+    /// Hashing algorithm for hashing a Data instance.
+    ///
+    /// - Parameters:
+    ///   - type: The type of hash to use.
+    ///   - output: The type of hash output desired, defaults to .hex.
+    ///   - Returns: The requested hash output or nil if failure.
+    public func hashed(_ type: HashType, output: HashOutputType = .hex) -> String? {
+
+        // setup data variable to hold hashed value
+        var digest = Data(count: Int(type.length))
+
+        _ = digest.withUnsafeMutableBytes{ digestBytes -> UInt8 in
+            self.withUnsafeBytes { messageBytes -> UInt8 in
+                if let mb = messageBytes.baseAddress, let db = digestBytes.bindMemory(to: UInt8.self).baseAddress {
+                    let length = CC_LONG(self.count)
+                    switch type {
+                    case .md5: CC_MD5(mb, length, db)
+                    case .sha1: CC_SHA1(mb, length, db)
+                    case .sha224: CC_SHA224(mb, length, db)
+                    case .sha256: CC_SHA256(mb, length, db)
+                    case .sha384: CC_SHA384(mb, length, db)
+                    case .sha512: CC_SHA512(mb, length, db)
+                    }
+                }
+                return 0
+            }
+        }
+
+        // return the value based on the specified output type.
+        switch output {
+        case .hex: return digest.map { String(format: "%02hhx", $0) }.joined()
+        case .base64: return digest.base64EncodedString()
+        }
+    }
+}

--- a/AudioKitSynthOne/About/Mailing List/MailchimpService.swift
+++ b/AudioKitSynthOne/About/Mailing List/MailchimpService.swift
@@ -1,0 +1,105 @@
+//
+//  MailchimpService.swift
+//  AudioKitSynthOne
+//
+//  Created by Matthias Frick on 31/10/2019.
+//  Copyright © 2019 AudioKit. All rights reserved.
+//
+
+import AudioKit
+import Foundation
+
+struct MailChimpUser {
+    public var listId: String
+    public var email_address: String
+    public let status = "subscribed"
+}
+
+class MailChimp {
+    public static let shared = MailChimp()
+    public var apiKey: String = "" {
+        didSet {
+          let listNumber = apiKey.split(separator: "-")
+          baseUrl = "https://\(listNumber[1]).api.mailchimp.com/3.0"
+        }
+    }
+    typealias ChimpCallback = (Data?, URLResponse?, Error?) -> ()
+    var baseUrl: String = "https://us15.api.mailchimp.com/3.0"
+
+    public func addSubscriber(user: MailChimpUser, completionHandler: ChimpCallback?) {
+        // prepare json data
+        let parameters: [String: Any] = [
+            "email_address": user.email_address,
+            "status": user.status,
+        ]
+        let jsonData = try? JSONSerialization.data(withJSONObject: parameters)
+
+        // create post request
+        let url = "\(baseUrl)/lists/\(user.listId)/members"
+
+        guard let requestUrl = URL(string: url) else { return }
+        var request = URLRequest(url: requestUrl)
+        request.httpMethod = "POST"
+        request.setValue("Basic \(createBase64LoginString())", forHTTPHeaderField: "Authorization")
+        request.httpBody = jsonData
+
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            guard let data = data, error == nil else {
+                print(error?.localizedDescription ?? "No data")
+                completionHandler?(nil, response, error)
+                return
+            }
+            let responseJSON = try? JSONSerialization.jsonObject(with: data, options: [])
+            if let responseJSON = responseJSON as? [String: Any] {
+                if (responseJSON["title"] as? String == "Member Exists") {
+                    AKLog("Need to resubscribe")
+                    self.resubscribe(user: user) { (data, response, error) in
+                        completionHandler?(data, response, error)
+                    }
+              }
+            }
+        }
+        task.resume()
+    }
+
+    public func resubscribe(user: MailChimpUser, completionHandler: ChimpCallback?) {
+        // If a user previously unsubscribed, we will send him an opt-in instead
+        // to avoid that others forcefully sign up third-parties
+        let parameters: [String: Any] = [
+            "status": "pending",
+        ]
+        let jsonData = try? JSONSerialization.data(withJSONObject: parameters)
+
+        guard let userEndpoint = user.email_address.lowercased().hashed(.md5) else {
+            return
+        }
+        let url = "\(baseUrl)/lists/\(user.listId)/members/\(userEndpoint)"
+
+        var request = URLRequest(url: URL(string: url)!)
+        request.httpMethod = "PUT"
+        request.setValue("Basic \(createBase64LoginString())", forHTTPHeaderField: "Authorization")
+        request.httpBody = jsonData
+
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            completionHandler?(data, response, error)
+            guard let data = data, error == nil else {
+                print(error?.localizedDescription ?? "No data")
+                return
+            }
+            let responseJSON = try? JSONSerialization.jsonObject(with: data, options: [])
+            if let responseJSON = responseJSON as? [String: Any] {
+                print(responseJSON)
+            }
+        }
+        task.resume()
+    }
+
+    // Helpers
+
+    private func createBase64LoginString() -> String {
+        let loginString = String(format: ":%@", apiKey)
+        let loginData = loginString.data(using: String.Encoding.utf8)!
+        let base64LoginString = loginData.base64EncodedString()
+        return base64LoginString
+    }
+}

--- a/AudioKitSynthOne/About/Mailing List/MailingListViewController.swift
+++ b/AudioKitSynthOne/About/Mailing List/MailingListViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import ChimpKit
 import MessageUI
 
 protocol MailingListDelegate: AnyObject {
@@ -42,7 +41,7 @@ class MailingListViewController: UIViewController, UITextFieldDelegate {
 
         // MailChimp API Key
         guard Private.MailChimpAPIKey != "***REMOVED***" else { return }
-        ChimpKit.shared().apiKey = Private.MailChimpAPIKey
+        MailChimp.shared.apiKey = Private.MailChimpAPIKey
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -152,22 +151,15 @@ class MailingListViewController: UIViewController, UITextFieldDelegate {
         let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
         let submitAction = UIAlertAction(title: "Yes 👍🏼", style: .default) { (_) in
 
-            // Send to MailChimp
-            let mailToSubscribe: [String: AnyObject] = ["email": emailAddress as AnyObject]
-            let params: [String: AnyObject] = ["id": Private.MailChimpID as AnyObject,
-                                               "email": mailToSubscribe as AnyObject,
-                                               "double_optin": false as AnyObject]
-            
-            // let userLanguage = NSLocale.current.languageCode
-            
-            ChimpKit.shared().callApiMethod("lists/subscribe", withParams: params) {(response, data, _) -> Void in
-                if let httpResponse = response as? HTTPURLResponse {
-                    NSLog("Reponse status code: %d", httpResponse.statusCode)
-                    if let actualData = data {
-                        let datastring = NSString(data: actualData, encoding: String.Encoding.utf8.rawValue)
-                        AKLog(datastring ?? "error with MailChimp response")
-                    }
-                }
+            let mailUser = MailChimpUser(
+                listId: Private.MailChimpID,
+                email_address: emailAddress
+            )
+
+            MailChimp.shared.addSubscriber(user: mailUser) { (data, response, error) in
+              if let httpResponse = response as? HTTPURLResponse {
+                AKLog("Reponse status code: %d", httpResponse.statusCode)
+              }
             }
             self.delegate?.didSignMailingList(email: emailAddress)
             self.emailSubmitted()

--- a/AudioKitSynthOne/Audiobus/Audiobus+MIDI.swift
+++ b/AudioKitSynthOne/Audiobus/Audiobus+MIDI.swift
@@ -9,6 +9,7 @@
 import Foundation
 import AudioKit
 
+#if !targetEnvironment(macCatalyst)
 extension Audiobus {
 
     // MARK: - Preparations
@@ -67,3 +68,4 @@ extension Audiobus {
         ABMIDIPortSendPacketList(midiSendPort, UnsafePointer(packetListPointer))
     }
 }
+#endif

--- a/AudioKitSynthOne/Audiobus/Conductor+Audiobus.swift
+++ b/AudioKitSynthOne/Audiobus/Conductor+Audiobus.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+#if !targetEnvironment(macCatalyst)
 extension Conductor {
 
   func setupAudioBusInput() {
@@ -49,4 +50,10 @@ extension Conductor {
         }
         Audiobus.client?.controller.addMIDIReceiverPort(midiInput)
     }
+}
+#endif
+
+// Stubs for macOS Cataylst
+extension Conductor {
+    func setupAudioBusInput() { }
 }

--- a/AudioKitSynthOne/Audiobus/Manager+Audiobus.swift
+++ b/AudioKitSynthOne/Audiobus/Manager+Audiobus.swift
@@ -7,7 +7,7 @@
 //
 
 // AudioBus MIDI Input & Preset Loading
-
+#if !targetEnvironment(macCatalyst)
 extension Manager: ABAudiobusControllerStateIODelegate {
 
     // MARK: - AudioBus Preset Delegate
@@ -27,3 +27,10 @@ extension Manager: ABAudiobusControllerStateIODelegate {
         }
     }
 }
+#endif
+
+// Stubs for MacOS Catalyst target
+
+#if targetEnvironment(macCatalyst)
+extension Manager: ABAudiobusControllerStateIODelegate { }
+#endif

--- a/AudioKitSynthOne/DSP/AudioKitSynthOne-Bridging-Header.h
+++ b/AudioKitSynthOne/DSP/AudioKitSynthOne-Bridging-Header.h
@@ -11,8 +11,9 @@
 #import "S1AudioUnit.h"
 #import "S1Parameter.h"
 #import "AKSynthOneRate.h"
+#if !TARGET_OS_MACCATALYST
 #import "Audiobus.h"
-
+#endif
 // Set the ABLETON_ENABLED user setting to 1 (at the project level) to enable Ableton Link support
 // Note: you will need the files from their SDK!
 #if ABLETON_ENABLED

--- a/AudioKitSynthOne/DSP/Conductor+Platform.swift
+++ b/AudioKitSynthOne/DSP/Conductor+Platform.swift
@@ -1,0 +1,46 @@
+//
+//  Conductor+Platform.swift
+//  AudioKitSynthOne
+//
+//  Created by Matthias Frick on 03/11/2019.
+//  Copyright © 2019 AudioKit. All rights reserved.
+//
+
+import Foundation
+
+#if !targetEnvironment(macCatalyst)
+extension Conductor {
+      @objc func checkIAAConnectionsEnterBackground() {
+
+          if let audiobusClient = Audiobus.client {
+
+              if !audiobusClient.isConnected && !audiobusClient.isConnectedToInput && !backgroundAudio {
+                  deactivateSession()
+                  AKLog("disconnected without timer")
+              } else {
+                  iaaTimer.invalidate()
+                  iaaTimer = Timer.scheduledTimer(timeInterval: 20 * 60,
+                                                  target: self,
+                                                  selector: #selector(self.checkIAAConnectionsEnterBackground),
+                                                  userInfo: nil, repeats: true)
+              }
+          }
+
+      }
+
+      func checkIAAConnectionsEnterForeground() {
+          iaaTimer.invalidate()
+          startEngine()
+      }
+}
+#endif
+
+// MacOS Cataylyst stubs
+// We don't support IAA there so adding NOOPs
+#if targetEnvironment(macCatalyst)
+extension Conductor {
+      @objc func checkIAAConnectionsEnterBackground() { }
+
+      func checkIAAConnectionsEnterForeground() { }
+}
+#endif

--- a/AudioKitSynthOne/DSP/Conductor.swift
+++ b/AudioKitSynthOne/DSP/Conductor.swift
@@ -31,7 +31,9 @@ class Conductor: S1Protocol {
 
     var sustainer: SDSustainer!
 
+  #if !targetEnvironment(macCatalyst)
     var midiInput: ABMIDIReceiverPort?
+  #endif
 
     var audioBusMidiDelegate: AKMIDIListener?
 
@@ -215,6 +217,7 @@ class Conductor: S1Protocol {
         }
         started = true
 
+        #if !targetEnvironment(macCatalyst)
         if let au = AudioKit.engine.outputNode.audioUnit {
             // IAA Host Icon
             audioUnitPropertyListener = AudioUnitPropertyListener { (_, _) in
@@ -233,6 +236,7 @@ class Conductor: S1Protocol {
         }
         Audiobus.start()
         setupAudioBusInput()
+        #endif
     }
 
     func updateDisplayLabel(_ message: String) {
@@ -307,28 +311,6 @@ class Conductor: S1Protocol {
 
     func stopEngine() {
         AudioKit.engine.pause()
-    }
-
-    @objc func checkIAAConnectionsEnterBackground() {
-
-        if let audiobusClient = Audiobus.client {
-
-            if !audiobusClient.isConnected && !audiobusClient.isConnectedToInput && !backgroundAudio {
-                deactivateSession()
-                AKLog("disconnected without timer")
-            } else {
-                iaaTimer.invalidate()
-                iaaTimer = Timer.scheduledTimer(timeInterval: 20 * 60,
-                                                target: self,
-                                                selector: #selector(self.checkIAAConnectionsEnterBackground),
-                                                userInfo: nil, repeats: true)
-            }
-        }
-    }
-
-    func checkIAAConnectionsEnterForeground() {
-        iaaTimer.invalidate()
-        startEngine()
     }
 
     func deactivateSession() {

--- a/AudioKitSynthOne/Header/HeaderViewContoller.swift
+++ b/AudioKitSynthOne/Header/HeaderViewContoller.swift
@@ -442,6 +442,7 @@ public class HeaderViewController: UpdatableViewController {
         var url: CFURL = CFURLCreateWithString(nil, "" as CFString?, nil)
         var size = UInt32(MemoryLayout<CFURL>.size)
 
+        #if !targetEnvironment(macCatalyst)
         guard let outputAudioUnit = AudioKit.engine.outputNode.audioUnit else { return }
         let result = AudioUnitGetProperty(
             outputAudioUnit,
@@ -454,6 +455,7 @@ public class HeaderViewController: UpdatableViewController {
         if result == noErr {
             UIApplication.shared.open(url as URL)
         }
+        #endif
     }
 
     func updateMailingListButton(_ signedMailingList: Bool) {

--- a/AudioKitSynthOne/Manager/Manager.swift
+++ b/AudioKitSynthOne/Manager/Manager.swift
@@ -243,6 +243,7 @@ public class Manager: UpdatableViewController {
         devViewController.view.removeFromSuperview()
 
         // IAA MIDI
+        #if !targetEnvironment(macCatalyst)
         var callbackStruct = AudioOutputUnitMIDICallbacks(
             userData: nil,
             MIDIEventProc: { (_, status, data1, data2, _) in
@@ -267,7 +268,7 @@ public class Manager: UpdatableViewController {
         if connectIAAMDI != 0 {
             AKLog("Cannot create outpoutAudioUnit of type: kAudioOutputUnitProperty_MIDICallbacks")
         }
-
+        #endif
 		holdButton.accessibilityValue = self.keyboardView.holdMode ?
 			NSLocalizedString("On", comment: "On") :
 			NSLocalizedString("Off", comment: "Off")

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,6 @@ def available_pods
     pod 'AudioKit', '= 4.9'
     pod 'Disk', '~> 0.3.2'
     pod 'Audiobus'
-    pod 'ChimpKit'
     pod 'OneSignal', '>= 2.6.2', '< 3.0'
 end
 


### PR DESCRIPTION
Hey everyone,
this is to document the effort that needs to be done for Catalyst.
Please beware that the Target-Conditionals in the code are just the "route of lowest effort" and in no way how we should do it (esp. when it comes to S1 internal stuff).
Instead we should rip out all Platform-dependent stuff so that we have to use these conditionals at only a few select places and not wildly all over the place as in this (only meant to visualise) PR. 

Apart from that we need to:

- [x] Abstract OneSignal and ChimpKit away from Platform dependency. 
**ChimpKit** does not compile for Cataylst (unsupported WebView calls, Framework is super old) Adressed in https://github.com/AudioKit/AudioKitSynthOne/pull/118
**OneSignal** (tbd)

- [x] Remove use of EZAudioPlotGL for Plotting (no OpenGL on Cataylst) in AudioKit, see https://github.com/AudioKit/AudioKit/issues/1802
Adressed in https://github.com/AudioKit/AudioKit/pull/1913 & https://github.com/AudioKit/AudioKit/pull/1912

- [ ] Cocoapods does not support xcframeworks, resulting in:
` building for Mac Catalyst, but linking in object file built for iOS Simulator`
options: a) ditch Cocoapods or b) wait for support or c) release special Catalyst one-off builds where we have to use AK as an Xcode Project file.

I will update this branch and list as I find out more.
**DO NOT MERGE!!!**