### PR TITLE
Replace ChimpKit SDK Dependency

### DIFF
--- a/AudioKitSynthOne.xcodeproj/project.pbxproj
+++ b/AudioKitSynthOne.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		48C3EE7437FA1B1E7916844E /* Pods_AudioKitSynthOne.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA27CDAC229BF66A1C649B42 /* Pods_AudioKitSynthOne.framework */; };
 		69115F3E2363BBA100B144A5 /* Conductor+Audiobus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69115F3D2363BBA000B144A5 /* Conductor+Audiobus.swift */; };
+		69C11CF7236C96DA00833BF7 /* MailchimpService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690F807A236B5B9D00FDC518 /* MailchimpService.swift */; };
+		69C11CF8236C96DC00833BF7 /* MD5Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C11CF3236C375B00833BF7 /* MD5Helpers.swift */; };
 		941645CD20B3597300D62851 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941645CC20B3597300D62851 /* NotificationService.swift */; };
 		941645D120B3597300D62851 /* OneSignalNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 941645CA20B3597300D62851 /* OneSignalNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		941752BA20E2BD2E0076D953 /* Starter Bank.json in Resources */ = {isa = PBXBuildFile; fileRef = 941752B920E2BD2E0076D953 /* Starter Bank.json */; };
@@ -298,7 +300,10 @@
 		45E1A7C3C54D27427C4A71B1 /* Pods_AKS1Extension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AKS1Extension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		51EC225D22B5EE94B01AA474 /* Pods-AudioKitSynthOne.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AudioKitSynthOne.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AudioKitSynthOne/Pods-AudioKitSynthOne.debug.xcconfig"; sourceTree = "<group>"; };
 		5FAA47B316A5F659F440DAC9 /* Pods-AKS1Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AKS1Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AKS1Extension/Pods-AKS1Extension.debug.xcconfig"; sourceTree = "<group>"; };
+		690F807A236B5B9D00FDC518 /* MailchimpService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailchimpService.swift; sourceTree = "<group>"; };
 		69115F3D2363BBA000B144A5 /* Conductor+Audiobus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Conductor+Audiobus.swift"; sourceTree = "<group>"; };
+		69C11CE4236C2F3700833BF7 /* AudioKit For iOS.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "AudioKit For iOS.xcodeproj"; path = "../AudioKit/AudioKit/iOS/AudioKit For iOS.xcodeproj"; sourceTree = "<group>"; };
+		69C11CF3236C375B00833BF7 /* MD5Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MD5Helpers.swift; sourceTree = "<group>"; };
 		69E4E45622381DF90049F0EA /* S1DSPCompressor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = S1DSPCompressor.hpp; sourceTree = "<group>"; };
 		90231BFB16779C7C2CD6CB3F /* Pods-AKS1Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AKS1Extension.release.xcconfig"; path = "Pods/Target Support Files/Pods-AKS1Extension/Pods-AKS1Extension.release.xcconfig"; sourceTree = "<group>"; };
 		9405503A210556C20039F101 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
@@ -1255,6 +1260,8 @@
 			children = (
 				EA388CFB2104995B0026C0C0 /* MailingList.storyboard */,
 				C4B4919620C7C81200FD565A /* Manager+MailingListDelegate.swift */,
+				690F807A236B5B9D00FDC518 /* MailchimpService.swift */,
+				69C11CF3236C375B00833BF7 /* MD5Helpers.swift */,
 				C4B4919720C7C81200FD565A /* MailingListViewController.swift */,
 			);
 			path = "Mailing List";
@@ -1834,6 +1841,7 @@
 				94189CB8219F27130004C28B /* MoreAppsController.swift in Sources */,
 				C4B4914020C7C6A000FD565A /* TouchPointStyleKit.swift in Sources */,
 				C435C4F820C5234900DAECCD /* CategoryCell.swift in Sources */,
+				69C11CF8236C96DC00833BF7 /* MD5Helpers.swift in Sources */,
 				C435C53120C52D4C00DAECCD /* Tunings+Math.swift in Sources */,
 				C435C58520C530C900DAECCD /* S1AudioUnit.mm in Sources */,
 				C4B4919020C7C7B200FD565A /* BankEditorViewController.swift in Sources */,
@@ -1948,6 +1956,7 @@
 				F473515722A0D63900869AFB /* TuningsViewController.swift in Sources */,
 				C45DF29C21016A0E000AB3FD /* LinkExtensions.swift in Sources */,
 				C4B4918E20C7C7A400FD565A /* Manager+PresetsDelegate.swift in Sources */,
+				69C11CF7236C96DA00833BF7 /* MailchimpService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AudioKitSynthOne.xcodeproj/project.pbxproj
+++ b/AudioKitSynthOne.xcodeproj/project.pbxproj
@@ -1726,12 +1726,10 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AudioKitSynthOne/Pods-AudioKitSynthOne-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/ChimpKit/ChimpKit.framework",
 				"${BUILT_PRODUCTS_DIR}/Disk/Disk.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ChimpKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Disk.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AudioKitSynthOne/About/Mailing List/MD5Helpers.swift
+++ b/AudioKitSynthOne/About/Mailing List/MD5Helpers.swift
@@ -1,0 +1,112 @@
+//
+//  MD5Helpers.swift
+//  AudioKitSynthOne
+//
+//  Created by Matthias Frick on 01/11/2019.
+//  Copyright © 2019 AudioKit. All rights reserved.
+//
+
+import Foundation
+import CommonCrypto
+
+// Helper function to create MD5 Hash
+// Needed for adressing endpoints in MailChimp API v3
+
+// Defines types of hash string outputs available
+public enum HashOutputType {
+    case hex
+    case base64
+}
+
+// Defines types of hash algorithms available
+public enum HashType {
+    case md5
+    case sha1
+    case sha224
+    case sha256
+    case sha384
+    case sha512
+
+    var length: Int32 {
+        switch self {
+        case .md5: return CC_MD5_DIGEST_LENGTH
+        case .sha1: return CC_SHA1_DIGEST_LENGTH
+        case .sha224: return CC_SHA224_DIGEST_LENGTH
+        case .sha256: return CC_SHA256_DIGEST_LENGTH
+        case .sha384: return CC_SHA384_DIGEST_LENGTH
+        case .sha512: return CC_SHA512_DIGEST_LENGTH
+        }
+    }
+}
+
+public extension String {
+
+    /// Hashing algorithm for hashing a string instance.
+    ///
+    /// - Parameters:
+    ///   - type: The type of hash to use.
+    ///   - output: The type of output desired, defaults to .hex.
+    /// - Returns: The requested hash output or nil if failure.
+    func hashed(_ type: HashType, output: HashOutputType = .hex) -> String? {
+        // convert string to utf8 encoded data
+        guard let message = data(using: .utf8) else { return nil }
+        return message.hashed(type, output: output)
+    }
+}
+
+extension Data {
+
+    /// Hashing algorithm that prepends an RSA2048ASN1Header to the beginning of the data being hashed.
+    ///
+    /// - Parameters:
+    ///   - type: The type of hash algorithm to use for the hashing operation.
+    ///   - output: The type of output string desired.
+    /// - Returns: A hash string using the specified hashing algorithm, or nil.
+    public func hashWithRSA2048Asn1Header(_ type: HashType, output: HashOutputType = .hex) -> String? {
+
+        let rsa2048Asn1Header:[UInt8] = [
+            0x30, 0x82, 0x01, 0x22, 0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86,
+            0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00, 0x03, 0x82, 0x01, 0x0f, 0x00
+        ]
+
+        var headerData = Data(rsa2048Asn1Header)
+        headerData.append(self)
+
+        return hashed(type, output: output)
+    }
+
+    /// Hashing algorithm for hashing a Data instance.
+    ///
+    /// - Parameters:
+    ///   - type: The type of hash to use.
+    ///   - output: The type of hash output desired, defaults to .hex.
+    ///   - Returns: The requested hash output or nil if failure.
+    public func hashed(_ type: HashType, output: HashOutputType = .hex) -> String? {
+
+        // setup data variable to hold hashed value
+        var digest = Data(count: Int(type.length))
+
+        _ = digest.withUnsafeMutableBytes{ digestBytes -> UInt8 in
+            self.withUnsafeBytes { messageBytes -> UInt8 in
+                if let mb = messageBytes.baseAddress, let db = digestBytes.bindMemory(to: UInt8.self).baseAddress {
+                    let length = CC_LONG(self.count)
+                    switch type {
+                    case .md5: CC_MD5(mb, length, db)
+                    case .sha1: CC_SHA1(mb, length, db)
+                    case .sha224: CC_SHA224(mb, length, db)
+                    case .sha256: CC_SHA256(mb, length, db)
+                    case .sha384: CC_SHA384(mb, length, db)
+                    case .sha512: CC_SHA512(mb, length, db)
+                    }
+                }
+                return 0
+            }
+        }
+
+        // return the value based on the specified output type.
+        switch output {
+        case .hex: return digest.map { String(format: "%02hhx", $0) }.joined()
+        case .base64: return digest.base64EncodedString()
+        }
+    }
+}

--- a/AudioKitSynthOne/About/Mailing List/MailchimpService.swift
+++ b/AudioKitSynthOne/About/Mailing List/MailchimpService.swift
@@ -1,0 +1,105 @@
+//
+//  MailchimpService.swift
+//  AudioKitSynthOne
+//
+//  Created by Matthias Frick on 31/10/2019.
+//  Copyright © 2019 AudioKit. All rights reserved.
+//
+
+import AudioKit
+import Foundation
+
+struct MailChimpUser {
+    public var listId: String
+    public var email_address: String
+    public let status = "subscribed"
+}
+
+class MailChimp {
+    public static let shared = MailChimp()
+    public var apiKey: String = "" {
+        didSet {
+          let listNumber = apiKey.split(separator: "-")
+          baseUrl = "https://\(listNumber[1]).api.mailchimp.com/3.0"
+        }
+    }
+    typealias ChimpCallback = (Data?, URLResponse?, Error?) -> ()
+    var baseUrl: String = "https://us15.api.mailchimp.com/3.0"
+
+    public func addSubscriber(user: MailChimpUser, completionHandler: ChimpCallback?) {
+        // prepare json data
+        let parameters: [String: Any] = [
+            "email_address": user.email_address,
+            "status": user.status,
+        ]
+        let jsonData = try? JSONSerialization.data(withJSONObject: parameters)
+
+        // create post request
+        let url = "\(baseUrl)/lists/\(user.listId)/members"
+
+        guard let requestUrl = URL(string: url) else { return }
+        var request = URLRequest(url: requestUrl)
+        request.httpMethod = "POST"
+        request.setValue("Basic \(createBase64LoginString())", forHTTPHeaderField: "Authorization")
+        request.httpBody = jsonData
+
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            guard let data = data, error == nil else {
+                print(error?.localizedDescription ?? "No data")
+                completionHandler?(nil, response, error)
+                return
+            }
+            let responseJSON = try? JSONSerialization.jsonObject(with: data, options: [])
+            if let responseJSON = responseJSON as? [String: Any] {
+                if (responseJSON["title"] as? String == "Member Exists") {
+                    AKLog("Need to resubscribe")
+                    self.resubscribe(user: user) { (data, response, error) in
+                        completionHandler?(data, response, error)
+                    }
+              }
+            }
+        }
+        task.resume()
+    }
+
+    public func resubscribe(user: MailChimpUser, completionHandler: ChimpCallback?) {
+        // If a user previously unsubscribed, we will send him an opt-in instead
+        // to avoid that others forcefully sign up third-parties
+        let parameters: [String: Any] = [
+            "status": "pending",
+        ]
+        let jsonData = try? JSONSerialization.data(withJSONObject: parameters)
+
+        guard let userEndpoint = user.email_address.lowercased().hashed(.md5) else {
+            return
+        }
+        let url = "\(baseUrl)/lists/\(user.listId)/members/\(userEndpoint)"
+
+        var request = URLRequest(url: URL(string: url)!)
+        request.httpMethod = "PUT"
+        request.setValue("Basic \(createBase64LoginString())", forHTTPHeaderField: "Authorization")
+        request.httpBody = jsonData
+
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            completionHandler?(data, response, error)
+            guard let data = data, error == nil else {
+                print(error?.localizedDescription ?? "No data")
+                return
+            }
+            let responseJSON = try? JSONSerialization.jsonObject(with: data, options: [])
+            if let responseJSON = responseJSON as? [String: Any] {
+                print(responseJSON)
+            }
+        }
+        task.resume()
+    }
+
+    // Helpers
+
+    private func createBase64LoginString() -> String {
+        let loginString = String(format: ":%@", apiKey)
+        let loginData = loginString.data(using: String.Encoding.utf8)!
+        let base64LoginString = loginData.base64EncodedString()
+        return base64LoginString
+    }
+}

--- a/AudioKitSynthOne/About/Mailing List/MailingListViewController.swift
+++ b/AudioKitSynthOne/About/Mailing List/MailingListViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import ChimpKit
 import MessageUI
 
 protocol MailingListDelegate: AnyObject {
@@ -42,7 +41,7 @@ class MailingListViewController: UIViewController, UITextFieldDelegate {
 
         // MailChimp API Key
         guard Private.MailChimpAPIKey != "***REMOVED***" else { return }
-        ChimpKit.shared().apiKey = Private.MailChimpAPIKey
+        MailChimp.shared.apiKey = Private.MailChimpAPIKey
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -152,22 +151,15 @@ class MailingListViewController: UIViewController, UITextFieldDelegate {
         let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
         let submitAction = UIAlertAction(title: "Yes 👍🏼", style: .default) { (_) in
 
-            // Send to MailChimp
-            let mailToSubscribe: [String: AnyObject] = ["email": emailAddress as AnyObject]
-            let params: [String: AnyObject] = ["id": Private.MailChimpID as AnyObject,
-                                               "email": mailToSubscribe as AnyObject,
-                                               "double_optin": false as AnyObject]
-            
-            // let userLanguage = NSLocale.current.languageCode
-            
-            ChimpKit.shared().callApiMethod("lists/subscribe", withParams: params) {(response, data, _) -> Void in
-                if let httpResponse = response as? HTTPURLResponse {
-                    NSLog("Reponse status code: %d", httpResponse.statusCode)
-                    if let actualData = data {
-                        let datastring = NSString(data: actualData, encoding: String.Encoding.utf8.rawValue)
-                        AKLog(datastring ?? "error with MailChimp response")
-                    }
-                }
+            let mailUser = MailChimpUser(
+                listId: Private.MailChimpID,
+                email_address: emailAddress
+            )
+
+            MailChimp.shared.addSubscriber(user: mailUser) { (data, response, error) in
+              if let httpResponse = response as? HTTPURLResponse {
+                AKLog("Reponse status code: %d", httpResponse.statusCode)
+              }
             }
             self.delegate?.didSignMailingList(email: emailAddress)
             self.emailSubmitted()

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,6 @@ def available_pods
     pod 'AudioKit', '= 4.9.2'
     pod 'Disk', '~> 0.3.2'
     pod 'Audiobus'
-    pod 'ChimpKit'
     pod 'OneSignal', '>= 2.6.2', '< 3.0'
 end
 


### PR DESCRIPTION
Hey everyone,

this PR removed the dependency on the ChimpKit SDK.
**Background**: The ChimpKit SDK repo has not been updated in 5-6 years and is showing it's age. It does not compile when using Catalyst (Catalina) as a target and it is using the deprecated APIv2 of MailChimp.
This API is well documented and I've written a little class against it.

**Changes**: ChimpKit is removed from PodFile. A new class called `MailChimp` is being put in place as a drop-in replacement with a similar API as before. Higher-level changes are therefore minimal.

**New**: Previously users had no choice to resubscribe when they unsubscribed in the past. This PR adds functionality and checks that - if a user had subscribed in the past, we will send him/her an "opt-in" email. The reason is that we might want to prevent malicious actors from signing up third-parties. This means:
1. If a user subscribes for the first time, the behaviour is the same as in the past.
2. If a user resubscribes, we will send an opt-in email.

I have tested and verified these behaviours with multiple accounts of my own.
@aure @analogcode if we use ChimpKit in other AK Apps, this may be a universal suitable replacement.