### PR TITLE
Add recording button

### DIFF
--- a/AudioKitSynthOne.xcodeproj/project.pbxproj
+++ b/AudioKitSynthOne.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		692C04F82370C43A008CBDDA /* AppDelegate+PlatformServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69824682236EE83A00407DF4 /* AppDelegate+PlatformServices.swift */; };
 		693709DD23760AEA00D3C321 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693709DC23760AEA00D3C321 /* AudioRecorder.swift */; };
 		6982467D236EDCE600407DF4 /* Conductor+Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6982467C236EDCE600407DF4 /* Conductor+Platform.swift */; };
+		69ACD757238E8CED0050AB38 /* MIDIRecordButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69ACD756238E8CED0050AB38 /* MIDIRecordButton.swift */; };
 		69C11CF7236C96DA00833BF7 /* MailchimpService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690F807A236B5B9D00FDC518 /* MailchimpService.swift */; };
 		69C11CF8236C96DC00833BF7 /* MD5Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C11CF3236C375B00833BF7 /* MD5Helpers.swift */; };
 		941645CD20B3597300D62851 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941645CC20B3597300D62851 /* NotificationService.swift */; };
@@ -308,6 +309,7 @@
 		693709DC23760AEA00D3C321 /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorder.swift; sourceTree = "<group>"; };
 		6982467C236EDCE600407DF4 /* Conductor+Platform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Conductor+Platform.swift"; sourceTree = "<group>"; };
 		69824682236EE83A00407DF4 /* AppDelegate+PlatformServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+PlatformServices.swift"; sourceTree = "<group>"; };
+		69ACD756238E8CED0050AB38 /* MIDIRecordButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIDIRecordButton.swift; sourceTree = "<group>"; };
 		69C11CF3236C375B00833BF7 /* MD5Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MD5Helpers.swift; sourceTree = "<group>"; };
 		69E4E45622381DF90049F0EA /* S1DSPCompressor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = S1DSPCompressor.hpp; sourceTree = "<group>"; };
 		90231BFB16779C7C2CD6CB3F /* Pods-AKS1Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AKS1Extension.release.xcconfig"; path = "Pods/Target Support Files/Pods-AKS1Extension/Pods-AKS1Extension.release.xcconfig"; sourceTree = "<group>"; };
@@ -985,6 +987,7 @@
 				F4C790132247025C003CFF28 /* MIDIStepper.swift */,
 				F4CA406E225192A60053F29E /* MIDISynthButton.swift */,
 				F4AD9EE1224856C2002B0E2E /* MIDIToggleButton.swift */,
+				69ACD756238E8CED0050AB38 /* MIDIRecordButton.swift */,
 				F4AD9EE3224866BE002B0E2E /* MIDIToggleSwitch.swift */,
 			);
 			path = MIDI;
@@ -1854,6 +1857,7 @@
 				C435C58520C530C900DAECCD /* S1AudioUnit.mm in Sources */,
 				C4B4919020C7C7B200FD565A /* BankEditorViewController.swift in Sources */,
 				C4B4915120C7C6FC00FD565A /* MIDISettingsViewController.swift in Sources */,
+				69ACD757238E8CED0050AB38 /* MIDIRecordButton.swift in Sources */,
 				C435C57E20C530C900DAECCD /* AEArray.m in Sources */,
 				C4B4918820C7C79C00FD565A /* Presets+PresetPopOverDelegate.swift in Sources */,
 				C435C50320C5286C00DAECCD /* Helpers.swift in Sources */,

--- a/AudioKitSynthOne/Generators/Base.lproj/Generators.storyboard
+++ b/AudioKitSynthOne/Generators/Base.lproj/Generators.storyboard
@@ -3,7 +3,7 @@
     <device id="ipad9_7" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -291,7 +291,7 @@
                                 <attributedString key="userComments">
                                     <fragment content="Amplification/Volume">
                                         <attributes>
-                                            <font key="NSFont" metaFont="label" size="11"/>
+                                            <font key="NSFont" metaFont="message" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
@@ -428,7 +428,7 @@
                                 <attributedString key="userComments">
                                     <fragment content="Stereo Widen">
                                         <attributes>
-                                            <font key="NSFont" metaFont="label" size="11"/>
+                                            <font key="NSFont" metaFont="message" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
@@ -446,7 +446,7 @@
                                 <attributedString key="userComments">
                                     <fragment content="Filter Resonance/Q ">
                                         <attributes>
-                                            <font key="NSFont" metaFont="label" size="11"/>
+                                            <font key="NSFont" metaFont="message" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
@@ -464,7 +464,7 @@
                                 <attributedString key="userComments">
                                     <fragment content="Filter Frequency">
                                         <attributes>
-                                            <font key="NSFont" metaFont="label" size="11"/>
+                                            <font key="NSFont" metaFont="message" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
@@ -502,7 +502,7 @@
                                 <attributedString key="userComments">
                                     <fragment content="Oscillator 1 / Digital Controlled Oscillator ">
                                         <attributes>
-                                            <font key="NSFont" metaFont="label" size="11"/>
+                                            <font key="NSFont" metaFont="message" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
@@ -538,7 +538,7 @@
                                 <attributedString key="userComments">
                                     <fragment content="Frequency Modulation / FM Synthesis">
                                         <attributes>
-                                            <font key="NSFont" metaFont="label" size="11"/>
+                                            <font key="NSFont" metaFont="message" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
@@ -663,7 +663,7 @@
                                 <attributedString key="userComments">
                                     <fragment content="arpeggiator/Sequencer (Perhaps one Abbreviation or the other, please keep short)">
                                         <attributes>
-                                            <font key="NSFont" metaFont="label" size="11"/>
+                                            <font key="NSFont" metaFont="message" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
@@ -697,7 +697,7 @@
                                 <attributedString key="userComments">
                                     <fragment content="Stereo Widen">
                                         <attributes>
-                                            <font key="NSFont" metaFont="label" size="11"/>
+                                            <font key="NSFont" metaFont="message" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
@@ -723,7 +723,7 @@
                                 <color key="textColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xZr-pB-ZAo" customClass="MIDIToggleButton" customModule="AudioKitSynthOne" customModuleProvider="target">
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xZr-pB-ZAo" customClass="MIDIRecordButton" customModule="AudioKitSynthOne" customModuleProvider="target">
                                 <rect key="frame" x="544" y="14" width="37" height="38"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -1054,7 +1054,7 @@
                                 <attributedString key="userComments">
                                     <fragment content="Frequency Modulation / FM Synthesis">
                                         <attributes>
-                                            <font key="NSFont" metaFont="label" size="11"/>
+                                            <font key="NSFont" metaFont="message" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
@@ -1231,7 +1231,7 @@
                                 <attributedString key="userComments">
                                     <fragment content="Filter Resonance/Q ">
                                         <attributes>
-                                            <font key="NSFont" metaFont="label" size="11"/>
+                                            <font key="NSFont" metaFont="message" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
@@ -1249,7 +1249,7 @@
                                 <attributedString key="userComments">
                                     <fragment content="Filter Frequency">
                                         <attributes>
-                                            <font key="NSFont" metaFont="label" size="11"/>
+                                            <font key="NSFont" metaFont="message" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
@@ -1394,7 +1394,7 @@
                                 <attributedString key="userComments">
                                     <fragment content="Oscillator 1 / Digital Controlled Oscillator ">
                                         <attributes>
-                                            <font key="NSFont" metaFont="label" size="11"/>
+                                            <font key="NSFont" metaFont="message" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
@@ -1412,7 +1412,7 @@
                                 <attributedString key="userComments">
                                     <fragment content="arpeggiator/Sequencer (Perhaps one Abbreviation or the other, please keep short)">
                                         <attributes>
-                                            <font key="NSFont" metaFont="label" size="11"/>
+                                            <font key="NSFont" metaFont="message" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
@@ -1462,13 +1462,13 @@
                                 <attributedString key="userComments">
                                     <fragment content="Filter Resonance/Q ">
                                         <attributes>
-                                            <font key="NSFont" metaFont="label" size="11"/>
+                                            <font key="NSFont" metaFont="message" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                         </attributes>
                                     </fragment>
                                 </attributedString>
                             </label>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Es8-TO-Cuo" customClass="MIDIToggleButton" customModule="AudioKitSynthOne" customModuleProvider="target">
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Es8-TO-Cuo" customClass="MIDIRecordButton" customModule="AudioKitSynthOne" customModuleProvider="target">
                                 <rect key="frame" x="387" y="6" width="30" height="31"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>

--- a/AudioKitSynthOne/Generators/GeneratorsPanelController.swift
+++ b/AudioKitSynthOne/Generators/GeneratorsPanelController.swift
@@ -68,7 +68,7 @@ class GeneratorsPanelController: PanelController, AudioRecorderViewDelegate {
     
     @IBOutlet weak var rezKnobLabel: UILabel!
 
-    @IBOutlet weak var recordButton: MIDIToggleButton!
+    @IBOutlet weak var recordButton: MIDIRecordButton!
 
     @IBOutlet weak var recordStatus: UILabel!
 

--- a/AudioKitSynthOne/MIDI/MIDIRecordButton.swift
+++ b/AudioKitSynthOne/MIDI/MIDIRecordButton.swift
@@ -1,0 +1,76 @@
+//
+//  MIDIToggleButton.swift
+//  AudioKitSynthOne
+//
+//  Created by Marcus W. Hobbs on 3/24/19.
+//  Copyright © 2019 AudioKit. All rights reserved.
+//
+
+class MIDIRecordButton: MIDIToggleButton {
+
+    var circleView = UIView()
+    var circleAnimator: UIViewPropertyAnimator?
+
+    // Styling for the Circle
+    static var recordColor = #colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1)
+    static var recordingAltColor = #colorLiteral(red: 0.1803921569, green: 0.1803921569, blue: 0.2, alpha: 1)
+
+    override var isOn: Bool {
+        didSet {
+            setNeedsDisplay()
+            accessibilityValue = isOn ? NSLocalizedString("On", comment: "On") : NSLocalizedString("Off", comment: "Off")
+            animateCircle()
+        }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    override func layoutSubviews() {
+        addCircle(frame: frame)
+    }
+
+
+    func animateCircle(reversed: Bool = false) {
+        if !isOn {
+            circleView.backgroundColor = MIDIRecordButton.recordColor
+            return
+        }
+
+        circleAnimator = UIViewPropertyAnimator(duration: 0.5, curve: .easeInOut, animations: {
+            self.circleView.backgroundColor = reversed ? MIDIRecordButton.recordColor : MIDIRecordButton.recordingAltColor
+        })
+        circleAnimator?.addCompletion({ (_) in
+            self.animateCircle(reversed: !reversed)
+        })
+        circleAnimator?.startAnimation()
+    }
+
+    func addCircle(frame: CGRect) {
+        // Paintcode Draw Code has an offset to the right/bottom side of the frame.
+        // This hack takes the offset into account as we scale the button
+        // between iPad and iPhone
+        let paintCodeWidthOffset = frame.size.width * 0.06
+        let paintCodeHeightOffset = frame.size.height * 0.1
+        let circleSize = CGSize(width: frame.width / 2.5, height: frame.width / 2.5)
+
+        circleView = UIView(frame: CGRect(
+            x: frame.width / 2 - circleSize.width / 2 - paintCodeWidthOffset,
+            y: frame.height / 2 - circleSize.width / 2 - paintCodeHeightOffset,
+            width: circleSize.width,
+            height: circleSize.height)
+        )
+
+        circleView.layer.cornerRadius = circleView.frame.height / 2
+        circleView.backgroundColor = MIDIRecordButton.recordColor
+        circleView.clipsToBounds = true
+
+        self.addSubview(circleView)
+        self.bringSubviewToFront(circleView)
+    }
+}


### PR DESCRIPTION
Here's an alternative take on https://github.com/AudioKit/AudioKitSynthOne/pull/124 with a little less code and reusing the `MIDIToggleButton`.

**Dev Changes**
We're using a new class called MIDIRecordButton that inherits from MIDIToggleButton.
Instead of using PaintCode we add a Circle Subview and when `isOn` is true, we animate
the backgroundColor of said Circle View.

**User Facing Changes**
The UI is now more in line with the rest of Synth One. An active recording is indicated by both the time progressed as well as the animated button.

@marcussatellite @analogcode adding the SubView in `layoutSubviews` is probably not the right place, let me know if you know of a better function for this.


<img width="981" alt="Screenshot 2019-11-27 at 19 21 41" src="https://user-images.githubusercontent.com/5174440/69749914-d14e2400-114b-11ea-9986-edad47808128.png">
<img width="981" alt="Screenshot 2019-11-27 at 19 21 37" src="https://user-images.githubusercontent.com/5174440/69749915-d14e2400-114b-11ea-8199-069036e4b2b6.png">
<img width="1500" alt="Screenshot 2019-11-27 at 19 26 20" src="https://user-images.githubusercontent.com/5174440/69749920-d4491480-114b-11ea-84e7-635fd4250f7b.png">


