### PR TITLE
Fix MIDIRecordButton double Callbacks

### DIFF
--- a/AudioKitSynthOne/MIDI/MIDIRecordButton.swift
+++ b/AudioKitSynthOne/MIDI/MIDIRecordButton.swift
@@ -73,4 +73,11 @@ class MIDIRecordButton: MIDIToggleButton {
         self.addSubview(circleView)
         self.bringSubviewToFront(circleView)
     }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        // NO OP
+        // TODO: We should fix this in ToggleButton.swift:52 because
+        // it will cause two callbacks (touchesBegan & touchesEnded)
+        // firing after each other
+    }
 }


### PR DESCRIPTION
**Dev Changes**
In `ToggleButton.swift` we define callbacks on both `touchesBegan` and `touchesEnded`.
Under certain conditions this results in two callbacks being fired rapidly after each other, one at the beginning and one at the end.
@marcussatellite I see you added this class, do you mind taking a look as to why we did this in the first place?

We should probably remove touchesEnded at some point, but I want to avoid introducing potentially breaking changes before rolling this out.

**User Changes**
Record button now behaves as expected and does not cause occasional immediate subsequent recordings anymore.