### PR TITLE
removed touchesEnded in ToggleButton to avoid double-callbacks of set…

### DIFF
--- a/AudioKitSynthOne/Controls/Buttons/ToggleButton.swift
+++ b/AudioKitSynthOne/Controls/Buttons/ToggleButton.swift
@@ -48,11 +48,4 @@ class ToggleButton: UIView, S1Control {
             setValueCallback(value)
         }
     }
-
-    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-
-        for _ in touches {
-            setValueCallback(value)
-        }
-    }
 }

--- a/AudioKitSynthOne/MIDI/MIDIRecordButton.swift
+++ b/AudioKitSynthOne/MIDI/MIDIRecordButton.swift
@@ -74,11 +74,4 @@ class MIDIRecordButton: MIDIToggleButton {
         self.addSubview(circleView)
         self.bringSubviewToFront(circleView)
     }
-
-    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-        // NO OP
-        // TODO: We should fix this in ToggleButton.swift:52 because
-        // it will cause two callbacks (touchesBegan & touchesEnded)
-        // firing after each other
-    }
 }


### PR DESCRIPTION
…ValueCallback

Tested:

FlatToggleButton: ToggleButton
*sequencerToggle
*widenToggle

iPhoneToggleButton: ToggleButton
*tempoSyncToggle
*reverbToggle
*delayToggle
*isMonoToggle
*widenToggle
*legatoModeToggle
*oscBandlimitEnable (antialiasing)
*sequencerToggle (arp)

MIDIToggleButton: ToggleButton
*arpToggle

MIDIRecordButton: MIDIToggleButton
*record