### PR TITLE
BUGFIX: Reorder bug reported by Francis Preve

### DIFF
--- a/AudioKitSynthOne/About/AboutViewController.swift
+++ b/AudioKitSynthOne/About/AboutViewController.swift
@@ -14,7 +14,6 @@ protocol AboutDelegate: AnyObject {
 }
 
 class AboutViewController: UIViewController {
-    
     @IBOutlet weak var parentView: UIView!
     @IBOutlet weak var textContainer: UIView!
     @IBOutlet weak var videoButton: SynthButton!
@@ -22,7 +21,6 @@ class AboutViewController: UIViewController {
     @IBOutlet weak var githubButton: SynthButton!
     @IBOutlet weak var mainTextView: UITextView!
     @IBOutlet weak var webButton: SynthButton!
-    
     weak var delegate: AboutDelegate?
     
     override func viewDidLoad() {
@@ -36,30 +34,31 @@ class AboutViewController: UIViewController {
         textContainer.layer.borderColor = #colorLiteral(red: 0.09411764706, green: 0.09411764706, blue: 0.09411764706, alpha: 1)
         textContainer.layer.borderWidth = 2
         textContainer.layer.cornerRadius = 8
-        
+
+        // callbacks
         setupCallbacks()
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
+        // layout
         self.mainTextView.setContentOffset(.zero, animated: false)
         
         // Fade in About Box
         UIView.animate(withDuration: 1, animations: {
             self.parentView.alpha = 1.0
         })
-        
         UIView.animate(withDuration: 1.5, animations: {
             self.textContainer.alpha = 1.0
         })
     }
     
     func setupCallbacks() {
-        
+
+        // github
         githubButton.setValueCallback = { _ in
             self.githubButton.value = 0
-            
             if Conductor.sharedInstance.device == .phone {
                 self.emailSend()
             } else {
@@ -68,22 +67,24 @@ class AboutViewController: UIViewController {
                 }
             }
         }
-        
+
+        // video
         videoButton.setValueCallback = { _ in
-            self.videoButton.value = 0
+            self.videoButton.value = 1
             if let url = URL(string: "http://youtu.be/hwDNgCYowYs") {
                 UIApplication.shared.open(url)
             }
         }
-        
+
+        // web
         webButton.setValueCallback = { _ in
             self.webButton.value = 0
             if let url = URL(string: "https://audiokitpro.com/synth") {
                 UIApplication.shared.open(url)
             }
         }
-        
-        
+
+        // reviews
         reviewButton.setValueCallback = { _ in
             self.reviewButton.value = 0
             self.requestReview()
@@ -118,18 +119,15 @@ class AboutViewController: UIViewController {
         let receipients = ["hello@audiokitpro.com"]
         let subject = "From AudioKit Synth App"
         let messageBody = ""
-        
         let configuredMailComposeViewController = configureMailComposeViewController(recepients: receipients,
                                                                                      subject: subject,
                                                                                      messageBody: messageBody)
-        
         if canSendMail() {
             self.present(configuredMailComposeViewController, animated: true, completion: nil)
         } else {
             showSendMailErrorAlert()
         }
     }
-    
 }
 
 // MARK: - MFMailComposeViewController Delegate
@@ -149,14 +147,11 @@ extension AboutViewController: MFMailComposeViewControllerDelegate {
     func configureMailComposeViewController(recepients: [String],
                                             subject: String,
                                             messageBody: String) -> MFMailComposeViewController {
-        
         let mailComposerVC = MFMailComposeViewController()
         mailComposerVC.mailComposeDelegate = self
-        
         mailComposerVC.setToRecipients(recepients)
         mailComposerVC.setSubject(subject)
         mailComposerVC.setMessageBody(messageBody, isHTML: false)
-        
         return mailComposerVC
     }
     
@@ -166,7 +161,6 @@ extension AboutViewController: MFMailComposeViewControllerDelegate {
             "Please check e-mail configuration and try again.",
                                                    preferredStyle: .alert)
         let cancelAction = UIAlertAction(title: "OK", style: .cancel, handler: nil)
-        
         sendMailErrorAlert.addAction(cancelAction)
         present(sendMailErrorAlert, animated: true, completion: nil)
     }

--- a/AudioKitSynthOne/Controls/Buttons/SynthButton.swift
+++ b/AudioKitSynthOne/Controls/Buttons/SynthButton.swift
@@ -53,11 +53,4 @@ class SynthButton: UIButton, S1Control {
             setValueCallback(value)
         }
     }
-
-//    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-//
-//        for _ in touches {
-//            setValueCallback(value)
-//        }
-//    }
 }

--- a/AudioKitSynthOne/Controls/Buttons/SynthButton.swift
+++ b/AudioKitSynthOne/Controls/Buttons/SynthButton.swift
@@ -54,10 +54,10 @@ class SynthButton: UIButton, S1Control {
         }
     }
 
-    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-
-        for _ in touches {
-            setValueCallback(value)
-        }
-    }
+//    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+//
+//        for _ in touches {
+//            setValueCallback(value)
+//        }
+//    }
 }

--- a/AudioKitSynthOne/Manager/Manager.swift
+++ b/AudioKitSynthOne/Manager/Manager.swift
@@ -10,88 +10,48 @@ import AudioKit
 import UIKit
 import Disk 
 
-
 protocol EmbeddedViewsDelegate: AnyObject {
-
     func switchToChildPanel(_ newView: ChildPanel, isOnTop: Bool)
-
 }
 
 public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
-
     @IBOutlet weak var topContainerView: UIView!
-
     @IBOutlet weak var bottomContainerView: UIView!
-
     @IBOutlet weak var keyboardView: KeyboardView!
-
     @IBOutlet var keyboardTopConstraint: NSLayoutConstraint!
-
     @IBOutlet var keyboardLeftConstraint: NSLayoutConstraint!
-
     @IBOutlet var keyboardRightConstraint: NSLayoutConstraint!
-
     @IBOutlet var topPanelheight: NSLayoutConstraint!
-
     @IBOutlet weak var midiButton: SynthButton!
-
     @IBOutlet weak var holdButton: MIDISynthButton!
-
     @IBOutlet weak var monoButton: MIDISynthButton!
-
     @IBOutlet weak var keyboardToggle: SynthButton!
-
     @IBOutlet weak var octaveStepper: Stepper!
-
     @IBOutlet weak var transposeStepper: MIDIStepper!
-
     @IBOutlet weak var configKeyboardButton: SynthButton!
-
     @IBOutlet weak var bluetoothButton: AKBluetoothMIDIButton!
-
     @IBOutlet weak var modWheelSettings: SynthButton!
-
     @IBOutlet weak var midiLearnToggle: SynthButton!
-
     @IBOutlet weak var pitchBend: AKVerticalPad!
-
     @IBOutlet weak var modWheelPad: AKVerticalPad!
-    
     @IBOutlet weak var linkButton: AKLinkButton!
-
     weak var embeddedViewsDelegate: EmbeddedViewsDelegate?
-
     var topChildPanel: ChildPanel?
-
     var bottomChildPanel: ChildPanel?
-
     var prevBottomChildPanel: ChildPanel?
-
     var isPresetsDisplayed: Bool = false
-
     var activePreset = Preset()
-
     var midiInputs = [MIDIInput]()
-
     var notesFromMIDI = Set<MIDINoteNumber>()
-
     var appSettings = AppSettings()
-
     var isDevView = false
-
     var sustainMode = false
-
     var pcJustTriggered = false
-
     var midiControls = [MIDILearnable]()
-
     var signedMailingList = false
-
-    let mainStoryboard = UIStoryboard(name: "Main", bundle: Bundle.main)
-
     var isPhoneX = false
-
     var isLoaded = false
+    let mainStoryboard = UIStoryboard(name: "Main", bundle: Bundle.main)
 
     // Python code to generate whiteKeysOnlyMap:
     // middleC = [60,60,61,61,62,63,63,64,64,65,65,66]
@@ -120,6 +80,7 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
     private var audioUnitPropertyListener: AudioUnitPropertyListener!
 
     // MARK: - Define child view controllers
+
     lazy var envelopesPanel: EnvelopesPanelController = {
         let envelopesStoryboard = UIStoryboard(name: "Envelopes", bundle: Bundle.main)
         var vcName = ChildPanel.envelopes.identifier()
@@ -184,7 +145,6 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        
         let modelName = UIDevice.current.modelName
         
         // Conductor start
@@ -222,6 +182,8 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
         // Load Presets
         displayPresetsController()
 
+        // MARK: - MIDI
+
         DispatchQueue.global(qos: .userInteractive).async {
             AudioKit.midi.createVirtualInputPort(95_433, name: "AudioKit Synth One")
             AudioKit.midi.openOutput(name: "AudioKit Synth One")
@@ -229,6 +191,7 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
         AudioKit.midi.addListener(self)
 
         // Pre-load views and Set initial subviews
+        // Inefficient and at odds with the definition of "lazy"
         switchToChildPanel(.sequencer, isOnTop: true)
         switchToChildPanel(.sequencer, isOnTop: false)
         switchToChildPanel(.effects, isOnTop: true)
@@ -242,7 +205,7 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
         add(asChildViewController: devViewController, isTopContainer: true)
         devViewController.view.removeFromSuperview()
 
-        // IAA MIDI
+        // MARK: - IAA MIDI
         #if !targetEnvironment(macCatalyst)
         var callbackStruct = AudioOutputUnitMIDICallbacks(
             userData: nil,
@@ -253,12 +216,10 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
                 print("Not handling sysex")
             }
         )
-
         guard let outputAudioUnit = AudioKit.engine.outputNode.audioUnit else {
             AKLog("ERROR: can't create outputAudioUnit")
             return
         }
-
         let connectIAAMDI = AudioUnitSetProperty(outputAudioUnit,
                                                  kAudioOutputUnitProperty_MIDICallbacks,
                                                  kAudioUnitScope_Global,
@@ -272,17 +233,14 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
 		holdButton.accessibilityValue = self.keyboardView.holdMode ?
 			NSLocalizedString("On", comment: "On") :
 			NSLocalizedString("Off", comment: "Off")
-
 		monoButton.accessibilityValue = self.keyboardView.polyphonicMode ?
 			NSLocalizedString("Off", comment: "Off") :
 			NSLocalizedString("On", comment: "On")
-        
         isPhoneX = modelName == "iPhone X" || modelName == "iPhone XS" || modelName == "iPhone XS Max" || modelName == "iPhone XR" || modelName == "iPhone 11" || modelName == "iPhone 11 Pro" || modelName == "iPhone 11 Pro Max"
         if isPhoneX {
             self.keyboardLeftConstraint?.constant = 72.5
             self.keyboardRightConstraint?.constant = 72.5
         }
-
        Audiobus.client?.controller.stateIODelegate = self
        conductor.audioBusMidiDelegate = self
     }
@@ -351,7 +309,6 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
             appSettings.presetsVersion = currentPresetVersion
             saveAppSettings()
         }
-
         presetsViewController.loadBanks()
 
         // Set Initial Preset from last used Bank & Preset
@@ -369,11 +326,9 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
             AKSettings.bufferLength = .veryLong
             try? AVAudioSession.sharedInstance().setPreferredIOBufferDuration(AKSettings.bufferLength.duration)
         }
-        
         if appSettings.firstRun && (modelName == "iPhone SE" || modelName == "iPhone 5s" || modelName == "iPhone 5c") {
             iPhoneRequirementWarning()
         }
-        
         if appSettings.firstRun && (modelName == "iPhone 6" || modelName == "iPhone 6s" || modelName == "iPhone 7" || modelName == "iPhone 8" || modelName == "iPhone 6 Plus" || modelName == "iPhone 6s Plus" || modelName == "iPhone 7 Plus" || modelName == "iPhone 8 Plus") {
             if UIScreen.main.nativeScale != UIScreen.main.scale {
                 iPhoneZoomWarning()
@@ -420,6 +375,7 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
         appSettings.firstRun = false
         saveAppSettingValues()
 
+        // midi controls
         appendMIDIControls(fromViewController: generatorsPanel)
         appendMIDIControls(fromViewController: envelopesPanel)
         appendMIDIControls(fromViewController: fxPanel)
@@ -430,8 +386,13 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
         appendMIDIControl(holdButton)
         appendMIDIControl(monoButton)
 
+        // link
         setupLinkStuff()
+
+        // audio recorder
         conductor.audioRecorder?.fileDelegate = self
+
+        // loading complete
         isLoaded = true
     }
 
@@ -465,13 +426,11 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
             AKLog("ParentViewController can't update global UI because synth is not instantiated")
             return
         }
-
         let isMono = s.getSynthParameter(.isMono)
         if isMono != monoButton.value {
             monoButton.value = isMono
             self.keyboardView.polyphonicMode = (isMono == 0) ? true : false
         }
-        
         if parameter == .cutoff {
             if inputControl === modWheelPad || activePreset.modWheelRouting != 0 {
                 return
@@ -488,7 +447,6 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
 
     func dependentParameterDidChange(_ dependentParameter: DependentParameter) {
         switch dependentParameter.parameter {
-
         case .lfo1Rate:
             if dependentParameter.payload == conductor.lfo1RateModWheelID {
                 return
@@ -496,7 +454,6 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
             if activePreset.modWheelRouting == 1 {
                 modWheelPad.setVerticalValue01(Double(dependentParameter.normalizedValue))
             }
-
         case .lfo2Rate:
             if dependentParameter.payload == conductor.lfo2RateModWheelID {
                 return
@@ -504,13 +461,11 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
             if activePreset.modWheelRouting == 2 {
                 modWheelPad.setVerticalValue01(Double(dependentParameter.normalizedValue))
             }
-
         case .pitchbend:
             if dependentParameter.payload == conductor.pitchBendID {
                 return
             }
             pitchBend.setVerticalValue01(Double(dependentParameter.normalizedValue))
-
         default:
             _ = 0
         }
@@ -521,14 +476,12 @@ public class Manager: UpdatableViewController, AudioRecorderFileDelegate {
         var filesToShare = [Any]()
         filesToShare.append(fileURL)
         let activityViewController = UIActivityViewController(activityItems: filesToShare, applicationActivities: nil)
-
         if UIDevice.current.userInterfaceIdiom == .pad {
             activityViewController.popoverPresentationController?.sourceView = self.view
             activityViewController.popoverPresentationController?.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)
             activityViewController.popoverPresentationController?.permittedArrowDirections = UIPopoverArrowDirection.init(rawValue: 0)
         }
         activityViewController.excludedActivityTypes = [.assignToContact]
-
         self.present(activityViewController, animated: false, completion: {})
     }
 }

--- a/AudioKitSynthOne/Presets/BankEditorViewController.swift
+++ b/AudioKitSynthOne/Presets/BankEditorViewController.swift
@@ -14,45 +14,40 @@ protocol BankPopOverDelegate: AnyObject {
 }
 
 class BankEditorViewController: UIViewController {
-
     @IBOutlet weak var nameTextField: UITextField!
     @IBOutlet weak var popupView: UIView!
     @IBOutlet weak var cancelButton: SynthButton!
     @IBOutlet weak var saveButton: SynthButton!
     @IBOutlet weak var deleteButton: SynthButton!
-
     weak var delegate: BankPopOverDelegate?
-
     var bankName = "bank name"
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         popupView.layer.borderColor = #colorLiteral(red: 0.1333333333, green: 0.1333333333, blue: 0.1333333333, alpha: 1)
         popupView.layer.borderWidth = 2
         popupView.layer.cornerRadius = 6
-
         nameTextField.text = bankName
-
         setupCallbacks()
     }
 
     func setupCallbacks() {
 
+        // cancel button
         cancelButton.setValueCallback = { _ in
             self.dismiss(animated: true, completion: nil)
         }
 
+        // save button
         saveButton.setValueCallback = { _ in
             self.delegate?.didFinishEditing(oldName: self.bankName, newName: self.nameTextField.text ?? "Unnamed")
             self.dismiss(animated: true, completion: nil)
         }
 
+        // delete button
         deleteButton.setValueCallback = { _ in
             self.delegate?.didDeleteBank(bankName: self.bankName)
             self.dismiss(animated: true, completion: nil)
         }
-
     }
-
 }

--- a/AudioKitSynthOne/Presets/PresetEditorViewController.swift
+++ b/AudioKitSynthOne/Presets/PresetEditorViewController.swift
@@ -19,17 +19,14 @@ class PresetEditorViewController: UIViewController {
     @IBOutlet weak var bankPicker: UIPickerView!
     @IBOutlet weak var saveButton: SynthButton!
     @IBOutlet weak var cancelButton: SynthButton!
-
     weak var delegate: PresetPopOverDelegate?
-
     var preset = Preset()
     var categories = [""]
-    let cellReuseIdentifier = "PopUpCell"
     var categoryIndex = 0
-
-    let conductor = Conductor.sharedInstance
     var pickerBankNames = [String]()
     var bankSelected = "BankA"
+    let cellReuseIdentifier = "PopUpCell"
+    let conductor = Conductor.sharedInstance
 
     // MARK: - Lifecycle
 
@@ -39,10 +36,12 @@ class PresetEditorViewController: UIViewController {
         // Register the table view cell class and its reuse id
         categoryTableView.register(UITableViewCell.self, forCellReuseIdentifier: cellReuseIdentifier)
 
+        // popup
         popupView.layer.borderColor = #colorLiteral(red: 0.1333333333, green: 0.1333333333, blue: 0.1333333333, alpha: 1)
         popupView.layer.borderWidth = 4
         popupView.layer.cornerRadius = 6
 
+        // name
         nameTextField.text = preset.name
         nameTextField.textColor = UIColor.black
 
@@ -60,21 +59,20 @@ class PresetEditorViewController: UIViewController {
             categories.append((PresetCategory(rawValue: i)?.description())!)
         }
 
+        // callbacks
         setupCallbacks()
-		
+
+        // category
 		categoryTableView.accessibilityLabel = NSLocalizedString("Categories", comment: "Categories")
 		categoryTableView.accessibilityHint = NSLocalizedString("Sets catagory for a preset.", comment: "Sets catagory for a preset.")
-		
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
         categoryTableView.reloadData()
 
         // Populate Preset current values
         categoryIndex = preset.category
-        
         let indexPath = IndexPath(row: categoryIndex, section: 0)
         guard preset.category >= 0 && preset.category < PresetCategory.categoryCount else { return }
         categoryTableView.selectRow(at: indexPath, animated: true, scrollPosition: .middle)
@@ -83,20 +81,16 @@ class PresetEditorViewController: UIViewController {
     // MARK: - IBActions
 
     func setupCallbacks() {
-
         cancelButton.setValueCallback = { _ in
             self.dismiss(animated: true, completion: nil)
         }
-
         saveButton.setValueCallback = { _ in
             self.delegate?.didFinishEditing(name: self.nameTextField.text ?? "Unnamed",
                                             category: self.categoryIndex,
                                             newBank: self.bankSelected)
             self.dismiss(animated: true, completion: nil)
         }
-
     }
-
 }
 
 // MARK: - TableViewDataSource

--- a/AudioKitSynthOne/Presets/PresetsViewController/Presets+BankPopOverDelegate.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/Presets+BankPopOverDelegate.swift
@@ -52,7 +52,6 @@ extension PresetsViewController: BankPopOverDelegate {
 
         // Remove from AppSettings
         presetsDelegate?.banksDidUpdate()
-
         updateCategoryTable()
         selectCategory(PresetCategory.bankStartingIndex)
         categoryIndex = PresetCategory.bankStartingIndex
@@ -60,6 +59,5 @@ extension PresetsViewController: BankPopOverDelegate {
 
         // Delete bank json file
         try? Disk.remove(bankName + ".json", from: .documents)
-
     }
 }

--- a/AudioKitSynthOne/Presets/PresetsViewController/Presets+CategoryDelegate.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/Presets+CategoryDelegate.swift
@@ -16,6 +16,7 @@ extension PresetsViewController: CategoryDelegate {
     }
 
     func bankShare() {
+
         // Get Bank to Share
         guard let bank = conductor.banks.first(where: { $0.position == bankIndex }) else { return }
         let bankName = bank.name
@@ -41,7 +42,6 @@ extension PresetsViewController: CategoryDelegate {
                                                               width: 0, height: 0)
             popoverPresentationController.permittedArrowDirections = []
         }
-
         self.present(activityViewController, animated: true, completion: nil)
     }
 

--- a/AudioKitSynthOne/Presets/PresetsViewController/Presets+LoadSaveManipulate.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/Presets+LoadSaveManipulate.swift
@@ -14,7 +14,6 @@ extension PresetsViewController {
 
     func loadBanks() {
         presets.removeAll()
-
         for bank in conductor.banks {
             let fileName = bank.name + ".json"
 
@@ -26,14 +25,12 @@ extension PresetsViewController {
                 saveAllPresetsIn(bank.name)
             }
         }
-
         sortPresets()
         updateCategoryTable()
         selectCurrentPreset()
     }
 
     func sortPresets() {
-
         switch categoryIndex {
 
         // Display Categories
@@ -73,6 +70,7 @@ extension PresetsViewController {
     }
 
     func randomizePresets() {
+
         // Generate random presets 🎲
         randomNumbers = GKShuffledDistribution(lowestValue: 0, highestValue: presets.count - 1)
     }
@@ -97,7 +95,6 @@ extension PresetsViewController {
     func parsePresetsFromData(data: Data) {
         let presetsJSON = try? JSONSerialization.jsonObject(with: data, options: [])
         guard let jsonArray = presetsJSON as? [Any] else { return }
-
         presets += Preset.parseDataToPresets(jsonArray: jsonArray)
     }
 
@@ -106,9 +103,7 @@ extension PresetsViewController {
         for (i, preset) in presetsToSave.enumerated() {
             preset.position = i
         }
-        
         presetsToSave.forEach { $0.name = $0.name.trimmingCharacters(in: .whitespacesAndNewlines) }
-
         do {
             try Disk.save(presetsToSave, to: .documents, as: bank + ".json")
             sortPresets()
@@ -119,9 +114,7 @@ extension PresetsViewController {
 
     // Save activePreset
     func savePreset(_ activePreset: Preset) {
-
         activePreset.userText = presetDescriptionField.text
-
         var updateExistingPreset = false
 
         // Check if preset name exists
@@ -130,17 +123,18 @@ extension PresetsViewController {
         }
 
         if updateExistingPreset {
+
             // Remove currentPreset and replace it with activePreset
             if let position = presets.firstIndex(where: { $0.uid == currentPreset.uid }) {
                 presets.remove(at: position)
                 presets.insert(activePreset, at: activePreset.position)
             }
         } else {
+
             // create new preset
             activePreset.uid = UUID().uuidString
             presets.insert(activePreset, at: activePreset.position + 1)
         }
-
         activePreset.isUser = true
         currentPreset = activePreset
         saveAllPresetsIn(currentPreset.bank)
@@ -176,6 +170,7 @@ extension PresetsViewController {
     }
 
     func selectCurrentPreset() {
+
         // Find the preset in the current view
         if let index = sortedPresets.firstIndex(where: { $0 === currentPreset }) {
             tableView.selectRow(at: IndexPath(row: index, section: 0), animated: true, scrollPosition: .middle)
@@ -194,12 +189,14 @@ extension PresetsViewController {
     }
 
    func upgradePresets(banksToUpdate: [String] = [""]) {
+
         // Remove existing presets
         // let banksToUpdate = ["Brice Beasley", "DJ Puzzle", "Red Sky Lullaby"]
     
         // If the bankName is not in conductorBanks, add bank to conductor banks
         for bankName in initBanks {
             if !conductor.banks.contains(where: { $0.name == bankName }) {
+
                 // Add bank to conductor banks
                 let bank = Bank(name: bankName, position: conductor.banks.count)
                 conductor.banks.append(bank)
@@ -213,9 +210,7 @@ extension PresetsViewController {
                     else { return }
                 let presetsJSON = try? JSONSerialization.jsonObject(with: data, options: [])
                 guard let jsonArray = presetsJSON as? [Any] else { return }
-                
                 let bundlePresets = Preset.parseDataToPresets(jsonArray: jsonArray)
-                
                 var newPresets: [Preset] = []
                 bundlePresets.forEach { preset in
                     // Check if preset name exists
@@ -223,7 +218,6 @@ extension PresetsViewController {
                         newPresets.append(preset)
                     }
                 }
-                
                 presets += newPresets
                 saveAllPresetsIn(bankName)
             }
@@ -232,6 +226,7 @@ extension PresetsViewController {
 
     func addBonusPresets() {
         let bankName = "BankA"
+
         // presets = presets.filter { $0.bank != bankName } // This replaces smaller BankA with Bonus.json file
         // Adds presets in Bonus.json to BankA
         loadFactoryPresets("Bonus")
@@ -252,9 +247,11 @@ extension PresetsViewController {
 
             // Save new preset in User Bank
             self.saveAllPresetsIn(self.currentPreset.bank)
+            self.selectCurrentPreset()
         }
 
         newBankButton.setValueCallback = { _ in
+
             // New Bank Name
             let newBankIndex = self.conductor.banks.count
             let newBankName = "Bank\(newBankIndex)"
@@ -296,7 +293,6 @@ extension PresetsViewController {
                 self.reorderButton.setTitleColor(#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1), for: .normal)
                 self.reorderButton.backgroundColor = #colorLiteral(red: 0.9019607843, green: 0.5333333333, blue: 0.007843137255, alpha: 1)
                 self.categoryEmbeddedView.isUserInteractionEnabled = false
-
             } else {
                 self.reorderButton.setTitle("Reorder", for: UIControl.State())
                 self.reorderButton.setTitleColor(#colorLiteral(red: 0.7333333333, green: 0.7333333333, blue: 0.7333333333, alpha: 1), for: .normal)
@@ -314,28 +310,22 @@ extension PresetsViewController {
 
     func nextPreset() {
         let presetBank = presets.filter { $0.bank == currentPreset.bank }.sorted { $0.position < $1.position }
-
         if currentPreset.position < presetBank.count - 1 {
             currentPreset = presetBank[currentPreset.position + 1]
-
         } else {
             currentPreset = presetBank[0]
         }
-
         selectCurrentPreset()
     }
 
     func previousPreset() {
         let presetBank = presets.filter { $0.bank == currentPreset.bank }.sorted { $0.position < $1.position }
-
         if currentPreset.position > 0 {
             currentPreset = presetBank[currentPreset.position + -1 ]
-
         } else {
             guard let lastPreset = presetBank.last else { return }
             currentPreset = lastPreset
         }
-
         selectCurrentPreset()
     }
 
@@ -346,12 +336,10 @@ extension PresetsViewController {
         // Get current Bank
         guard let currentBank = conductor.banks.first(where: { $0.position == bankIndex }) else { return }
         let presetsInBank = presets.filter { $0.bank == currentBank.name }.sorted { $0.position < $1.position }
-
         if (presetsInBank.count == 0) { return }
 
         // Smoothly cycle through presets if MIDI input is greater than preset count
         let currentPresetIndex = index % (presetsInBank.count)
-
         currentPreset = presetsInBank[currentPresetIndex]
         selectCurrentPreset()
     
@@ -359,7 +347,6 @@ extension PresetsViewController {
 
     // Used for Selecting Bank from MIDI msb (cc0)
     func didSelectBank(index: Int) {
-
         var newBankIndex = index
         if newBankIndex < 0 {
             newBankIndex = 0
@@ -384,17 +371,16 @@ extension PresetsViewController {
     }
 
     func addNewBank(newBankName: String, newBankIndex: Int) {
+
         // Add new bank to App settings
         let newBank = Bank(name: newBankName, position: newBankIndex)
         self.conductor.banks.append(newBank)
-
         self.presetsDelegate?.banksDidUpdate()
 
         // Add Bank to left category listing
         self.updateCategoryTable()
         self.selectCategory(PresetCategory.bankStartingIndex + newBankIndex)
         self.self.categoryIndex = PresetCategory.bankStartingIndex + newBankIndex
-
         self.sortPresets()
     }
 }

--- a/AudioKitSynthOne/Presets/PresetsViewController/Presets+PresetCellDelegate.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/Presets+PresetCellDelegate.swift
@@ -15,8 +15,8 @@ extension PresetsViewController: PresetCellDelegate {
     }
 
     func duplicatePressed() {
-
         do {
+            
             // Make unique copy of preset
             try Disk.save(currentPreset, to: .caches, as: "tmp/presetcopy.json")
             guard let copy = try? Disk.retrieve("tmp/presetcopy.json", from: .caches, as: Preset.self) else { return }
@@ -46,13 +46,13 @@ extension PresetsViewController: PresetCellDelegate {
             selectCategory(userBankIndex)
             categoryIndex = userBankIndex
             selectCurrentPreset()
-
         } catch {
             AKLog("error duplicating")
         }
     }
 
     func favoritePressed() {
+
         // Toggle and save preset
         currentPreset.isFavorite = !currentPreset.isFavorite
         saveAllPresetsIn(currentPreset.bank)
@@ -75,7 +75,6 @@ extension PresetsViewController: PresetCellDelegate {
         activityViewController.excludedActivityTypes = [
             UIActivity.ActivityType.copyToPasteboard
         ]
-
         if let popoverPresentationController = activityViewController.popoverPresentationController {
             popoverPresentationController.sourceView = self.view
             popoverPresentationController.sourceRect = CGRect(x: self.view.bounds.midX,
@@ -83,7 +82,6 @@ extension PresetsViewController: PresetCellDelegate {
                                                               width: 0, height: 0)
             popoverPresentationController.permittedArrowDirections = []
         }
-
         self.present(activityViewController, animated: true, completion: nil)
     }
 

--- a/AudioKitSynthOne/Presets/PresetsViewController/Presets+SearchDelegate.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/Presets+SearchDelegate.swift
@@ -13,11 +13,10 @@ extension PresetsViewController: SearchControllerDelegate {
     func didSelectPreset(_ newPreset: Preset) {
         deselectCurrentRow()
         
-        // Select Crrent Bank
+        // Select Current Bank
         guard let currentBank = conductor.banks.first(where: { $0.name == newPreset.bank }) else { return }
         selectCategory(PresetCategory.bankStartingIndex + currentBank.position )
         categoryIndex = PresetCategory.bankStartingIndex + currentBank.position
-        
         currentPreset = newPreset
         selectCurrentPreset()
     }

--- a/AudioKitSynthOne/Presets/PresetsViewController/Presets+UIDocumentPickerDelegate.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/Presets+UIDocumentPickerDelegate.swift
@@ -66,7 +66,6 @@ extension PresetsViewController: UIDocumentPickerDelegate {
                     importedPreset.isFavorite = false
                     importedPreset.isUser = true
                     presets.append(importedPreset)
-
                     currentPreset = importedPreset
                     currentPreset.bank = userBankName
                     saveAllPresetsIn(currentPreset.bank)
@@ -75,13 +74,11 @@ extension PresetsViewController: UIDocumentPickerDelegate {
                     selectCategory(userBankIndex)
                     categoryIndex = userBankIndex
                     selectCurrentPreset()
-
-                    AKLog("*** preset loaded")
+                    //AKLog("*** preset loaded")
                 }
             } else {
                 AKLog("*** error parsing presets")
             }
-
         } catch {
             AKLog("*** error loading")
         }

--- a/AudioKitSynthOne/Presets/PresetsViewController/PresetsViewController.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/PresetsViewController.swift
@@ -24,14 +24,18 @@ class PresetsViewController: UIViewController {
     @IBOutlet weak var reorderButton: SynthButton!
     @IBOutlet weak var importBankButton: PresetUIButton!
     @IBOutlet weak var newBankButton: PresetUIButton!
-
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var categoryEmbeddedView: UIView!
     @IBOutlet weak var presetDescriptionField: UITextView!
     @IBOutlet weak var categoryLabel: UILabel!
     @IBOutlet weak var doneEditingButton: UIButton!
     @IBOutlet weak var searchtoolButton: PresetUIButton!
-    
+    let conductor = Conductor.sharedInstance
+    let userBankIndex = PresetCategory.bankStartingIndex + 1
+    let userBankName = "User"
+    var randomNumbers: GKRandomDistribution!
+    weak var presetsDelegate: PresetsDelegate?
+
     var presets = [Preset]() {
         didSet {
             randomizePresets()
@@ -65,15 +69,6 @@ class PresetsViewController: UIViewController {
         if newIndex < 0 { newIndex = 0 }
         return newIndex
     }
-
-    let conductor = Conductor.sharedInstance
-    let userBankIndex = PresetCategory.bankStartingIndex + 1
-    let userBankName = "User"
-
-    var randomNumbers: GKRandomDistribution!
-
-    weak var presetsDelegate: PresetsDelegate?
-
 
     // MARK: - Lifecycle
 
@@ -133,5 +128,4 @@ class PresetsViewController: UIViewController {
             popOverController.presets = presets
         }
     }
-    
 }

--- a/AudioKitSynthOne/Presets/PresetsViewController/PresetsViewController.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/PresetsViewController.swift
@@ -18,7 +18,6 @@ protocol PresetsDelegate: AnyObject {
 }
 
 class PresetsViewController: UIViewController {
-
     @IBOutlet weak var newButton: SynthButton!
     @IBOutlet weak var importButton: SynthButton!
     @IBOutlet weak var reorderButton: SynthButton!
@@ -30,11 +29,12 @@ class PresetsViewController: UIViewController {
     @IBOutlet weak var categoryLabel: UILabel!
     @IBOutlet weak var doneEditingButton: UIButton!
     @IBOutlet weak var searchtoolButton: PresetUIButton!
+    weak var presetsDelegate: PresetsDelegate?
+    var randomNumbers: GKRandomDistribution!
+    var tempPreset = Preset()
     let conductor = Conductor.sharedInstance
     let userBankIndex = PresetCategory.bankStartingIndex + 1
     let userBankName = "User"
-    var randomNumbers: GKRandomDistribution!
-    weak var presetsDelegate: PresetsDelegate?
 
     var presets = [Preset]() {
         didSet {
@@ -55,8 +55,6 @@ class PresetsViewController: UIViewController {
             categoryLabel.text = PresetCategory(rawValue: currentPreset.category)?.description()
         }
     }
-
-    var tempPreset = Preset()
 
     var categoryIndex: Int = 0 {
         didSet {
@@ -90,7 +88,6 @@ class PresetsViewController: UIViewController {
 
         // Setup button callbacks
         setupCallbacks()
-
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/AudioKitSynthOne/Tunings/TuningsPanelController/TuningsPanelController.swift
+++ b/AudioKitSynthOne/Tunings/TuningsPanelController/TuningsPanelController.swift
@@ -36,9 +36,9 @@ class TuningsPanelController: PanelController {
     var tuningTableView = UITableView()
     var tuningViewController = TuningsViewController()
     var tuningTableEditButton: UIBarButtonItem?
-    let tuningModel = Tunings()
     internal var swipeGestureStarted: Bool = false
     internal var selectedIndexPath: IndexPath?
+    let tuningModel = Tunings()
 
     public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil,bundle: nibBundleOrNil)
@@ -121,6 +121,8 @@ class TuningsPanelController: PanelController {
                 self.tuningModel.frequencyA4 = value
                 self.conductor.updateDisplayLabel(.frequencyA4, value: synth.getSynthParameter(.frequencyA4))
             }
+
+            // reset tunings
             resetTuningsButton.setValueCallback = { value in
                 if value == 1 {
                     self.tuningModel.resetTuning()
@@ -130,6 +132,8 @@ class TuningsPanelController: PanelController {
                     self.conductor.updateDisplayLabel("Tuning Reset: 12ET/440")
                 }
             }
+
+            // import tunings (not yet implemented...UI element is not displayed)
             importButton.setValueCallback = { _ in
                 self.importButton.value = 0
                 let documentPicker = UIDocumentPickerViewController(documentTypes: [(kUTTypeText as String)], in: .import)
@@ -137,7 +141,7 @@ class TuningsPanelController: PanelController {
                 self.present(documentPicker, animated: true, completion: nil)
             }
         } else {
-            AKLog("race condition: synth not yet created")
+            AKLog("ERROR: race condition: synth not yet created")
         }
 
         /// model


### PR DESCRIPTION
BUGFIX: Preset reorder bug, reported by Francis Preve

Impacts all instances of "SynthButton"

Tested:

PASSED
AboutViewController.swift
    @IBOutlet weak var videoButton: SynthButton! // should always be true
    @IBOutlet weak var reviewButton: SynthButton!
    @IBOutlet weak var githubButton: SynthButton!
    @IBOutlet weak var webButton: SynthButton!


PASSED
MIDISettingsViewController.swift
    @IBOutlet weak var resetButton: SynthButton!


PASSED
Manager.swift
    @IBOutlet weak var midiButton: SynthButton!
    @IBOutlet weak var keyboardToggle: SynthButton!
    @IBOutlet weak var configKeyboardButton: SynthButton!
    @IBOutlet weak var modWheelSettings: SynthButton!
    @IBOutlet weak var midiLearnToggle: SynthButton!


PASSED
BankEditorViewController.swift
    @IBOutlet weak var cancelButton: SynthButton!
    @IBOutlet weak var saveButton: SynthButton!
    @IBOutlet weak var deleteButton: SynthButton!


PASSED
PresetEditorViewController.swift
    @IBOutlet weak var saveButton: SynthButton!
    @IBOutlet weak var cancelButton: SynthButton!


PASSED
TouchPadPanelController.swift
    @IBOutlet weak var snapToggle: SynthButton!


PASSED
TuningsPanelController.swift
    @IBOutlet weak var resetTuningsButton: SynthButton!
    @IBOutlet weak var importButton: SynthButton!
    @IBOutlet weak var tuneUpBackButtonButton: SynthButton!
    @IBOutlet weak var tuneUpButton: SynthButton!
