### PR TITLE
Split dsp message queues

### DIFF
--- a/AudioKitSynthOne/DSP/Audio Unit/S1AudioUnit.h
+++ b/AudioKitSynthOne/DSP/Audio Unit/S1AudioUnit.h
@@ -54,44 +54,35 @@ typedef struct S1ArpBeatCounter {
 
 
 @protocol S1Protocol
-
 -(void)dependentParameterDidChange:(DependentParameter)dependentParam;
-
 -(void)arpBeatCounterDidChange:(S1ArpBeatCounter)arpBeatCounter;
-
 -(void)heldNotesDidChange:(HeldNotes)heldNotes;
-
 -(void)playingNotesDidChange:(PlayingNotes)playingNotes;
-
 @end
 
 @interface S1AudioUnit : AKAudioUnit
 {
     @public
-    AEMessageQueue  *_messageQueue;
+    AEMessageQueue* _messageQueueDependentParameter;
+    AEMessageQueue* _messageQueueBeatCounter;
+    AEMessageQueue* _messageQueuePlayingNotes;
+    AEMessageQueue* _messageQueueHeldNotes;
 }
-
 @property (nonatomic) NSArray *parameters;
 @property (nonatomic, weak) id<S1Protocol> s1Delegate;
-
-
 - (float)getSynthParameter:(S1Parameter)param;
 - (void)setSynthParameter:(S1Parameter)param value:(float)value;
 - (float)getDependentParameter:(S1Parameter)param;
 - (void)setDependentParameter:(S1Parameter)param value:(float)value payload:(int)payload;
-
 - (float)getMinimum:(S1Parameter)param;
 - (float)getMaximum:(S1Parameter)param;
 - (float)getDefault:(S1Parameter)param;
-
 - (void)setupWaveform:(UInt32)tableIndex size:(int)size;
 - (void)setWaveform:(UInt32)tableIndex withValue:(float)value atIndex:(UInt32)sampleIndex;
 - (void)setBandlimitFrequency:(UInt32)blIndex withFrequency:(float)frequency;
-
 - (void)stopNote:(uint8_t)note;
 - (void)startNote:(uint8_t)note velocity:(uint8_t)velocity;
 - (void)startNote:(uint8_t)note velocity:(uint8_t)velocity frequency:(float)frequency;
-
 - (void)reset;
 - (void)stopAllNotes;
 - (void)resetDSP;

--- a/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+didChanges.mm
+++ b/AudioKitSynthOne/DSP/Kernel/S1DSPKernel+didChanges.mm
@@ -12,7 +12,7 @@
 #import "S1NoteState.hpp"
 
 void S1DSPKernel::dependentParameterDidChange(DependentParameter param) {
-    AEMessageQueuePerformSelectorOnMainThread(audioUnit->_messageQueue,
+    AEMessageQueuePerformSelectorOnMainThread(audioUnit->_messageQueueDependentParameter,
                                               audioUnit,
                                               @selector(dependentParameterDidChange:),
                                               AEArgumentStruct(param),
@@ -22,7 +22,7 @@ void S1DSPKernel::dependentParameterDidChange(DependentParameter param) {
 //can be called from within the render loop
 void S1DSPKernel::beatCounterDidChange() {
     S1ArpBeatCounter beatCounter = {sequencer.getArpBeatCount(), heldNoteNumbersAE.count};
-    AEMessageQueuePerformSelectorOnMainThread(audioUnit->_messageQueue,
+    AEMessageQueuePerformSelectorOnMainThread(audioUnit->_messageQueueBeatCounter,
                                               audioUnit,
                                               @selector(arpBeatCounterDidChange:),
                                               AEArgumentStruct(beatCounter),
@@ -44,7 +44,7 @@ void S1DSPKernel::playingNotesDidChange() {
             aePlayingNotes.playingNotes[i] = { note.rootNoteNumber, note.transpose, note.velocity, note.amp };
         }
     }
-    AEMessageQueuePerformSelectorOnMainThread(audioUnit->_messageQueue,
+    AEMessageQueuePerformSelectorOnMainThread(audioUnit->_messageQueuePlayingNotes,
                                               audioUnit,
                                               @selector(playingNotesDidChange:),
                                               AEArgumentStruct(aePlayingNotes),
@@ -62,7 +62,7 @@ void S1DSPKernel::heldNotesDidChange() {
         ++count;
     }
     aeHeldNotes.heldNotesCount = count;
-    AEMessageQueuePerformSelectorOnMainThread(audioUnit->_messageQueue,
+    AEMessageQueuePerformSelectorOnMainThread(audioUnit->_messageQueueHeldNotes,
                                               audioUnit,
                                               @selector(heldNotesDidChange:),
                                               AEArgumentStruct(aeHeldNotes),


### PR DESCRIPTION
Many crashes are in the message queue after it’s been dispatched…very difficult to debug.

Create a dsp/main thread message queue for each type of event:

AEMessageQueue* _messageQueueDependentParameter;
AEMessageQueue* _messageQueueBeatCounter;
AEMessageQueue* _messageQueuePlayingNotes;
AEMessageQueue* _messageQueueHeldNotes;