### PR TITLE
Subclass message queues for crash reports

### DIFF
--- a/AudioKitSynthOne.xcodeproj/project.pbxproj
+++ b/AudioKitSynthOne.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		F40636FD22E3EACC00A422D3 /* TuningsPitchWheelOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40636FC22E3EACC00A422D3 /* TuningsPitchWheelOverlayView.swift */; };
 		F40636FF22E3EECB00A422D3 /* KeyboardView+Draw12ET.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40636FE22E3EECB00A422D3 /* KeyboardView+Draw12ET.swift */; };
 		F406370122E3EF7F00A422D3 /* KeyboardView+DrawMicrotonal.swift in Sources */ = {isa = PBXBuildFile; fileRef = F406370022E3EF7F00A422D3 /* KeyboardView+DrawMicrotonal.swift */; };
+		F4658CA623F7C00900C1AB62 /* S1MessageQueues.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4658CA523F7C00900C1AB62 /* S1MessageQueues.mm */; };
 		F473515722A0D63900869AFB /* TuningsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F473515622A0D63900869AFB /* TuningsViewController.swift */; };
 		F47C27E42207C12100CA7541 /* Tunings+TuneUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47C27E32207C12100CA7541 /* Tunings+TuneUp.swift */; };
 		F47C27E62207C74000CA7541 /* TuningsPanel+TuneUpDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47C27E52207C74000CA7541 /* TuningsPanel+TuneUpDelegate.swift */; };
@@ -654,6 +655,8 @@
 		F40636FE22E3EECB00A422D3 /* KeyboardView+Draw12ET.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyboardView+Draw12ET.swift"; sourceTree = "<group>"; };
 		F406370022E3EF7F00A422D3 /* KeyboardView+DrawMicrotonal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyboardView+DrawMicrotonal.swift"; sourceTree = "<group>"; };
 		F437E99E20EB22D00096FEAC /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		F4658CA423F7BACD00C1AB62 /* S1MessageQueues.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = S1MessageQueues.h; sourceTree = "<group>"; };
+		F4658CA523F7C00900C1AB62 /* S1MessageQueues.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = S1MessageQueues.mm; sourceTree = "<group>"; };
 		F473515622A0D63900869AFB /* TuningsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TuningsViewController.swift; sourceTree = "<group>"; };
 		F47C27E32207C12100CA7541 /* Tunings+TuneUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tunings+TuneUp.swift"; sourceTree = "<group>"; };
 		F47C27E52207C74000CA7541 /* TuningsPanel+TuneUpDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuningsPanel+TuneUpDelegate.swift"; sourceTree = "<group>"; };
@@ -1068,6 +1071,8 @@
 			children = (
 				C435C56F20C530C900DAECCD /* S1AudioUnit.h */,
 				C435C57020C530C900DAECCD /* S1AudioUnit.mm */,
+				F4658CA423F7BACD00C1AB62 /* S1MessageQueues.h */,
+				F4658CA523F7C00900C1AB62 /* S1MessageQueues.mm */,
 			);
 			path = "Audio Unit";
 			sourceTree = "<group>";
@@ -1960,6 +1965,7 @@
 				C4B4916720C7C72A00FD565A /* PanelController.swift in Sources */,
 				C4B491BE20C7DEB100FD565A /* ArpDirectionStyleKit.swift in Sources */,
 				C4B4916A20C7C72A00FD565A /* UpdatableViewController.swift in Sources */,
+				F4658CA623F7C00900C1AB62 /* S1MessageQueues.mm in Sources */,
 				F40636FB22E3EA2300A422D3 /* String+Drawing.swift in Sources */,
 				C435C57C20C530C900DAECCD /* AEMessageQueue.m in Sources */,
 				C4B4910520C7C5C500FD565A /* ArpDirectionButton.swift in Sources */,

--- a/AudioKitSynthOne/DSP/Audio Unit/S1AudioUnit.h
+++ b/AudioKitSynthOne/DSP/Audio Unit/S1AudioUnit.h
@@ -10,11 +10,11 @@
 
 #import <AudioKit/AKAudioUnit.h>
 #import "S1Parameter.h"
+#import "S1MessageQueues.h"
 
 #define S1_MAX_POLYPHONY (6)
 #define S1_NUM_MIDI_NOTES (128)
 
-@class AEMessageQueue;
 
 // helper for midi/render thread communication: held+playing notes
 typedef struct NoteNumber {
@@ -63,10 +63,10 @@ typedef struct S1ArpBeatCounter {
 @interface S1AudioUnit : AKAudioUnit
 {
     @public
-    AEMessageQueue* _messageQueueDependentParameter;
-    AEMessageQueue* _messageQueueBeatCounter;
-    AEMessageQueue* _messageQueuePlayingNotes;
-    AEMessageQueue* _messageQueueHeldNotes;
+    AEMessageQueueDependentParameter* _messageQueueDependentParameter;
+    AEMessageQueueBeatCounter* _messageQueueBeatCounter;
+    AEMessageQueuePlayingNotes* _messageQueuePlayingNotes;
+    AEMessageQueueHeldNotes* _messageQueueHeldNotes;
 }
 @property (nonatomic) NSArray *parameters;
 @property (nonatomic, weak) id<S1Protocol> s1Delegate;

--- a/AudioKitSynthOne/DSP/Audio Unit/S1AudioUnit.mm
+++ b/AudioKitSynthOne/DSP/Audio Unit/S1AudioUnit.mm
@@ -143,10 +143,10 @@
 #pragma mark - Parameters
 
 - (void)createParameters {
-    _messageQueueDependentParameter = [[AEMessageQueue alloc] init];
-    _messageQueueBeatCounter = [[AEMessageQueue alloc] init];
-    _messageQueuePlayingNotes = [[AEMessageQueue alloc] init];
-    _messageQueueHeldNotes = [[AEMessageQueue alloc] init];
+    _messageQueueDependentParameter = [[AEMessageQueueDependentParameter alloc] init];
+    _messageQueueBeatCounter = [[AEMessageQueueBeatCounter alloc] init];
+    _messageQueuePlayingNotes = [[AEMessageQueuePlayingNotes alloc] init];
+    _messageQueueHeldNotes = [[AEMessageQueueHeldNotes alloc] init];
     self.rampDuration = AKSettings.rampDuration;
     self.defaultFormat = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:AKSettings.sampleRate channels:AKSettings.channelCount];
     _kernel = std::make_unique<S1DSPKernel>(self.defaultFormat.channelCount, self.defaultFormat.sampleRate);

--- a/AudioKitSynthOne/DSP/Audio Unit/S1MessageQueues.h
+++ b/AudioKitSynthOne/DSP/Audio Unit/S1MessageQueues.h
@@ -1,0 +1,26 @@
+//
+//  S1MessageQueues.h
+//  AudioKitSynthOne
+//
+//  Created by Marcus W. Hobbs on 2/14/20.
+//  Copyright © 2020 AudioKit. All rights reserved.
+//
+
+#ifndef S1MessageQueues_h
+#define S1MessageQueues_h
+
+#import "AEMessageQueue.h"
+
+@interface AEMessageQueueDependentParameter: AEMessageQueue
+@end
+
+@interface AEMessageQueueBeatCounter: AEMessageQueue
+@end
+
+@interface AEMessageQueuePlayingNotes: AEMessageQueue
+@end
+
+@interface AEMessageQueueHeldNotes: AEMessageQueue
+@end
+
+#endif /* S1MessageQueues_h */

--- a/AudioKitSynthOne/DSP/Audio Unit/S1MessageQueues.mm
+++ b/AudioKitSynthOne/DSP/Audio Unit/S1MessageQueues.mm
@@ -1,0 +1,21 @@
+//
+//  S1MessageQueues.mm
+//  AudioKitSynthOne
+//
+//  Created by Marcus W. Hobbs on 2/14/20.
+//  Copyright © 2020 AudioKit. All rights reserved.
+//
+
+#import "S1MessageQueues.h"
+
+@implementation AEMessageQueueDependentParameter: AEMessageQueue
+@end
+
+@implementation AEMessageQueueBeatCounter: AEMessageQueue
+@end
+
+@implementation AEMessageQueuePlayingNotes: AEMessageQueue
+@end
+
+@implementation AEMessageQueueHeldNotes: AEMessageQueue
+@end


### PR DESCRIPTION
Subclass message queues for crash reports, which report class names in stack traces.

i.e., 
@interface AEMessageQueueDependentParameter: AEMessageQueue
@end

@interface AEMessageQueueBeatCounter: AEMessageQueue
@end

@interface AEMessageQueuePlayingNotes: AEMessageQueue
@end

@interface AEMessageQueueHeldNotes: AEMessageQueue
@end
