### PR TITLE
Random preset in bank

### DIFF
--- a/AudioKitSynthOne/Header/HeaderViewContoller.swift
+++ b/AudioKitSynthOne/Header/HeaderViewContoller.swift
@@ -352,7 +352,6 @@ public class HeaderViewController: UpdatableViewController {
         case .oscBandlimitEnable:
             let obe = s.getSynthParameter(.oscBandlimitEnable) > 0 ? "On" : "Off"
             displayLabel.text = "Anti-Aliasing: \(obe)"
-
         case .adsrPitchTracking:
             displayLabel.text = "ADSR Pitch Tracking: \(s.getSynthParameter(.adsrPitchTracking).decimalString)"
         case .isMono:
@@ -382,10 +381,10 @@ public class HeaderViewController: UpdatableViewController {
     }
 
     @IBAction func morePressed(_ sender: UIButton) {
-
     }
 
     @IBAction func randomPressed(_ sender: UIButton) {
+
         // Animate Dice
         UIView.animate(withDuration: 0.4, animations: {
             for _ in 0 ... 1 {

--- a/AudioKitSynthOne/Presets/Manager+PresetsDelegate.swift
+++ b/AudioKitSynthOne/Presets/Manager+PresetsDelegate.swift
@@ -19,6 +19,8 @@ extension Manager: PresetsDelegate {
 
         // Set parameters from preset
         self.loadPreset()
+
+        // udpate ui
         DispatchQueue.main.async {
             self.conductor.updateAllUI()
         }

--- a/AudioKitSynthOne/Presets/PresetsViewController/Presets+LoadSaveManipulate.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/Presets+LoadSaveManipulate.swift
@@ -191,8 +191,7 @@ extension PresetsViewController {
    func upgradePresets(banksToUpdate: [String] = [""]) {
 
         // Remove existing presets
-        // let banksToUpdate = ["Brice Beasley", "DJ Puzzle", "Red Sky Lullaby"]
-    
+
         // If the bankName is not in conductorBanks, add bank to conductor banks
         for bankName in initBanks {
             if !conductor.banks.contains(where: { $0.name == bankName }) {
@@ -225,16 +224,14 @@ extension PresetsViewController {
     }
 
     func addBonusPresets() {
-        let bankName = "BankA"
 
-        // presets = presets.filter { $0.bank != bankName } // This replaces smaller BankA with Bonus.json file
         // Adds presets in Bonus.json to BankA
+        let bankName = "BankA"
         loadFactoryPresets("Bonus")
         saveAllPresetsIn(bankName)
     }
 
     func setupCallbacks() {
-
         newButton.setValueCallback = { _ in
             let userBankCount = self.presets.filter { $0.bank == self.userBankName }.count
             let initPreset = Preset(position: userBankCount)
@@ -286,8 +283,10 @@ extension PresetsViewController {
                 self.categoryIndex = PresetCategory.bankStartingIndex
             }
 
-            self.selectCategory(self.categoryIndex) // select category in category table
+            // select category in category table
+            self.selectCategory(self.categoryIndex)
 
+            // handle editing
             if self.tableView.isEditing {
                 self.reorderButton.setTitle("I'M DONE!", for: UIControl.State())
                 self.reorderButton.setTitleColor(#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1), for: .normal)
@@ -365,7 +364,9 @@ extension PresetsViewController {
 
         // Pick random Preset
         var newIndex = randomNumbers.nextInt()
-        if newIndex == currentPreset.position { newIndex = randomNumbers.nextInt() }
+        if newIndex == currentPreset.position {
+            newIndex = randomNumbers.nextInt()
+        }
         currentPreset = presets[newIndex]
         selectCurrentPreset()
     }

--- a/AudioKitSynthOne/Presets/PresetsViewController/Presets+UITableViewDataSource.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/Presets+UITableViewDataSource.swift
@@ -28,19 +28,14 @@ extension PresetsViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 
         // Get current preset
-
         if let cell = tableView.dequeueReusableCell(withIdentifier: "PresetCell") as? PresetCell {
-
             var alphabetical = false
             if categoryIndex == PresetCategory.categoryCount + 1 { alphabetical = true }
-
             let preset = sortedPresets[(indexPath as NSIndexPath).row]
-           
             cell.delegate = self
             
             // Cell updated in PresetCell.swift
             cell.configureCell(preset: preset, alpha: alphabetical)
-            
             return cell
         } else {
             return PresetCell()

--- a/AudioKitSynthOne/Presets/PresetsViewController/PresetsViewController.swift
+++ b/AudioKitSynthOne/Presets/PresetsViewController/PresetsViewController.swift
@@ -35,15 +35,11 @@ class PresetsViewController: UIViewController {
     let conductor = Conductor.sharedInstance
     let userBankIndex = PresetCategory.bankStartingIndex + 1
     let userBankName = "User"
-
-    var presets = [Preset]() {
-        didSet {
-            randomizePresets()
-        }
-    }
+    var presets = [Preset]()
 
     var sortedPresets = [Preset]() {
         didSet {
+            randomizePresets()
             tableView.reloadData()
         }
     }

--- a/AudioKitSynthOne/Presets/SearchViewController.swift
+++ b/AudioKitSynthOne/Presets/SearchViewController.swift
@@ -86,7 +86,6 @@ extension SearchViewController: UISearchBarDelegate, UISearchResultsUpdating {
             } else {
                 filteredPresets = presets
             }
-          
             filteredPresets.sort { $0.name.lowercased() < $1.name.lowercased() }
             tableView.reloadData()
         }
@@ -122,14 +121,9 @@ extension SearchViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
         // Get current preset
-        
         if let cell = tableView.dequeueReusableCell(withIdentifier: "PresetCell") as? PresetCell {
-            
             let preset = filteredPresets[(indexPath as NSIndexPath).row]
-           
-            // Cell updated in PresetCell.swift
             cell.configureCell(preset: preset, alpha: true)
-            
             return cell
         } else {
             return PresetCell()
@@ -144,12 +138,9 @@ extension SearchViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         resultSearchController.dismiss(animated: true, completion: nil)
-        
-        // Get cell
         let cell = tableView.cellForRow(at: indexPath) as? PresetCell
         guard let newPreset = cell?.currentPreset else { return }
         delegate?.didSelectPreset(newPreset)
-        
         dismiss(animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
When a user presses the randomize preset button select a random preset in the current bank.

Backwards compatibility: select the "all" bank and then press the randomize preset button